### PR TITLE
COS-4: Showing up the Oddo custom fields under the Custom Data configuration page and it’s disabling on extension disable.

### DIFF
--- a/CRM/Odoosync/Upgrader.php
+++ b/CRM/Odoosync/Upgrader.php
@@ -228,7 +228,7 @@ class CRM_Odoosync_Upgrader extends CRM_Odoosync_Upgrader_Base {
    */
   private function enableExtensionOptionGroups() {
     foreach ($this->optionGroups as $optionGroupName) {
-      $this->toggleOptionGroupActivity($optionGroupName, TRUE);
+      $this->toggleOptionGroup($optionGroupName, TRUE);
     }
   }
 
@@ -239,7 +239,7 @@ class CRM_Odoosync_Upgrader extends CRM_Odoosync_Upgrader_Base {
    */
   private function enableExtensionCustomGroups() {
     foreach ($this->customGroups as $customGroupName) {
-      $this->toggleCustomGroupActivity($customGroupName, TRUE);
+      $this->toggleCustomGroup($customGroupName, TRUE);
     }
   }
 
@@ -250,7 +250,7 @@ class CRM_Odoosync_Upgrader extends CRM_Odoosync_Upgrader_Base {
    */
   private function disableExtensionCustomGroups() {
     foreach ($this->customGroups as $customGroupName) {
-      $this->toggleCustomGroupActivity($customGroupName, FALSE);
+      $this->toggleCustomGroup($customGroupName, FALSE);
     }
   }
 
@@ -261,7 +261,7 @@ class CRM_Odoosync_Upgrader extends CRM_Odoosync_Upgrader_Base {
    */
   private function disableExtensionOptionGroups() {
     foreach ($this->optionGroups as $optionGroupName) {
-      $this->toggleOptionGroupActivity($optionGroupName, FALSE);
+      $this->toggleOptionGroup($optionGroupName, FALSE);
     }
   }
 
@@ -273,7 +273,7 @@ class CRM_Odoosync_Upgrader extends CRM_Odoosync_Upgrader_Base {
    *
    * @throws \CiviCRM_API3_Exception
    */
-  private function toggleOptionGroupActivity($name, $isActive) {
+  private function toggleOptionGroup($name, $isActive) {
     civicrm_api3('OptionGroup', 'get', [
       'name' => $name,
       'api.OptionGroup.create' => [
@@ -291,7 +291,7 @@ class CRM_Odoosync_Upgrader extends CRM_Odoosync_Upgrader_Base {
    *
    * @throws \CiviCRM_API3_Exception
    */
-  private function toggleCustomGroupActivity($name, $isActive) {
+  private function toggleCustomGroup($name, $isActive) {
     $customGroup = civicrm_api3('CustomGroup', 'getsingle', [
       'name' => $name,
       'return' => ['id']

--- a/CRM/Odoosync/Upgrader.php
+++ b/CRM/Odoosync/Upgrader.php
@@ -7,6 +7,29 @@
 class CRM_Odoosync_Upgrader extends CRM_Odoosync_Upgrader_Base {
 
   /**
+   * Custom groups created by the extension
+   *
+   * @var array
+   */
+  private $customGroups = [
+    'odoo_invoice_sync_information',
+    'odoo_partner_sync_information',
+    'purchase_order'
+  ];
+
+  /**
+   * Option groups created by the extension
+   *
+   * @var array
+   */
+  private $optionGroups = [
+    'msg_tpl_workflow_odoo_sync',
+    'odoo_sync_status',
+    'odoo_partner_action_to_sync',
+    'odoo_invoice_action_to_sync'
+  ];
+
+  /**
    * @throws \CiviCRM_API3_Exception
    */
   public function install() {
@@ -23,8 +46,26 @@ class CRM_Odoosync_Upgrader extends CRM_Odoosync_Upgrader_Base {
   }
 
   /**
-   * This hook call when extension uninstall
+   * Run when a module is enabled.
    *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function enable() {
+    $this->enableExtensionOptionGroups();
+    $this->enableExtensionCustomGroups();
+  }
+
+  /**
+   * Run when a module is disabled.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function disable() {
+    $this->disableExtensionOptionGroups();
+    $this->disableExtensionCustomGroups();
+  }
+
+  /**
    * @throws \CiviCRM_API3_Exception
    */
   public function uninstall() {
@@ -39,9 +80,7 @@ class CRM_Odoosync_Upgrader extends CRM_Odoosync_Upgrader_Base {
    * @throws \CiviCRM_API3_Exception
    */
   private function deleteExtensionOptionGroups() {
-    $optionGroupsToDelete = ['msg_tpl_workflow_odoo_sync', 'odoo_sync_status', 'odoo_partner_action_to_sync', 'odoo_invoice_action_to_sync'];
-
-    foreach ($optionGroupsToDelete as $optionGroupName) {
+    foreach ($this->optionGroups as $optionGroupName) {
       $this->deleteOptionGroup($optionGroupName);
     }
   }
@@ -64,9 +103,7 @@ class CRM_Odoosync_Upgrader extends CRM_Odoosync_Upgrader_Base {
    * @throws \CiviCRM_API3_Exception
    */
   private function deleteExtensionCustomGroups() {
-    $customGroupsToDelete = ['odoo_invoice_sync_information', 'odoo_partner_sync_information', 'purchase_order'];
-
-    foreach ($customGroupsToDelete as $customGroupName) {
+    foreach ($this->customGroups as $customGroupName) {
       $this->deleteCustomGroup($customGroupName);
     }
   }
@@ -182,6 +219,87 @@ class CRM_Odoosync_Upgrader extends CRM_Odoosync_Upgrader_Base {
     ]);
 
     return (int) $id;
+  }
+
+  /**
+   * Enables all the option groups created by the extension
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function enableExtensionOptionGroups() {
+    foreach ($this->optionGroups as $optionGroupName) {
+      $this->toggleOptionGroupActivity($optionGroupName, TRUE);
+    }
+  }
+
+  /**
+   * Enables all the custom groups created by the extension
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function enableExtensionCustomGroups() {
+    foreach ($this->customGroups as $customGroupName) {
+      $this->toggleCustomGroupActivity($customGroupName, TRUE);
+    }
+  }
+
+  /**
+   * Disables all the custom groups created by the extension
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function disableExtensionCustomGroups() {
+    foreach ($this->customGroups as $customGroupName) {
+      $this->toggleCustomGroupActivity($customGroupName, FALSE);
+    }
+  }
+
+  /**
+   * Disables all the option groups created by the extension
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function disableExtensionOptionGroups() {
+    foreach ($this->optionGroups as $optionGroupName) {
+      $this->toggleOptionGroupActivity($optionGroupName, FALSE);
+    }
+  }
+
+  /**
+   * Sets is_active for OptionGroups
+   *
+   * @param string $name
+   * @param bool $isActive
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function toggleOptionGroupActivity($name, $isActive) {
+    civicrm_api3('OptionGroup', 'get', [
+      'name' => $name,
+      'api.OptionGroup.create' => [
+        'id' => '$value.id',
+        'is_active' => (int) $isActive
+      ],
+    ]);
+  }
+
+  /**
+   * Sets is_active for CustomGroups
+   *
+   * @param string $name
+   * @param bool $isActive
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function toggleCustomGroupActivity($name, $isActive) {
+    $customGroup = civicrm_api3('CustomGroup', 'getsingle', [
+      'name' => $name,
+      'return' => ['id']
+    ]);
+
+    if (isset($customGroup['id'])) {
+      CRM_Core_BAO_CustomGroup::setIsActive((int) $customGroup['id'], $isActive);
+    }
   }
 
 }

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -4,7 +4,7 @@
         <OptionGroup>
             <name>msg_tpl_workflow_odoo_sync</name>
             <title>Message Template Workflow for Odoo Sync</title>
-            <is_reserved>1</is_reserved>
+            <is_reserved>0</is_reserved>
             <is_active>1</is_active>
         </OptionGroup>
     </OptionGroups>
@@ -15,7 +15,7 @@
             <value>1</value>
             <is_default>1</is_default>
             <weight>1</weight>
-            <is_reserved>1</is_reserved>
+            <is_reserved>0</is_reserved>
             <is_active>1</is_active>
             <option_group_name>msg_tpl_workflow_odoo_sync</option_group_name>
             <description>CiviCRM Odoo Sync Error Report</description>
@@ -25,7 +25,7 @@
         <OptionGroup>
             <name>odoo_sync_status</name>
             <title>Sync status</title>
-            <is_reserved>1</is_reserved>
+            <is_reserved>0</is_reserved>
             <is_active>1</is_active>
         </OptionGroup>
     </OptionGroups>
@@ -36,7 +36,7 @@
             <value>1</value>
             <is_default>1</is_default>
             <weight>1</weight>
-            <is_reserved>1</is_reserved>
+            <is_reserved>0</is_reserved>
             <is_active>1</is_active>
             <option_group_name>odoo_sync_status</option_group_name>
             <description>Awaiting sync status</description>
@@ -47,7 +47,7 @@
             <value>2</value>
             <is_default>0</is_default>
             <weight>2</weight>
-            <is_reserved>1</is_reserved>
+            <is_reserved>0</is_reserved>
             <is_active>1</is_active>
             <option_group_name>odoo_sync_status</option_group_name>
             <description>Synced status</description>
@@ -58,7 +58,7 @@
             <name>sync_failed</name>
             <is_default>0</is_default>
             <weight>3</weight>
-            <is_reserved>1</is_reserved>
+            <is_reserved>0</is_reserved>
             <is_active>1</is_active>
             <option_group_name>odoo_sync_status</option_group_name>
             <description>Sync failed status</description>
@@ -68,7 +68,7 @@
         <OptionGroup>
             <name>odoo_partner_action_to_sync</name>
             <title>Action to Sync</title>
-            <is_reserved>1</is_reserved>
+            <is_reserved>0</is_reserved>
             <is_active>1</is_active>
         </OptionGroup>
     </OptionGroups>
@@ -79,7 +79,7 @@
             <value>1</value>
             <is_default>1</is_default>
             <weight>1</weight>
-            <is_reserved>1</is_reserved>
+            <is_reserved>0</is_reserved>
             <is_active>1</is_active>
             <option_group_name>odoo_partner_action_to_sync</option_group_name>
             <description>Create action to sync</description>
@@ -90,7 +90,7 @@
             <value>2</value>
             <is_default>0</is_default>
             <weight>2</weight>
-            <is_reserved>1</is_reserved>
+            <is_reserved>0</is_reserved>
             <is_active>1</is_active>
             <option_group_name>odoo_partner_action_to_sync</option_group_name>
             <description>Update action to sync</description>
@@ -100,7 +100,7 @@
         <OptionGroup>
             <name>odoo_invoice_action_to_sync</name>
             <title>Action to Sync</title>
-            <is_reserved>1</is_reserved>
+            <is_reserved>0</is_reserved>
             <is_active>1</is_active>
         </OptionGroup>
     </OptionGroups>
@@ -111,7 +111,7 @@
             <value>1</value>
             <is_default>1</is_default>
             <weight>1</weight>
-            <is_reserved>1</is_reserved>
+            <is_reserved>0</is_reserved>
             <is_active>1</is_active>
             <option_group_name>odoo_invoice_action_to_sync</option_group_name>
             <description>Create action to sync</description>
@@ -122,7 +122,7 @@
             <value>2</value>
             <is_default>0</is_default>
             <weight>2</weight>
-            <is_reserved>1</is_reserved>
+            <is_reserved>0</is_reserved>
             <is_active>1</is_active>
             <option_group_name>odoo_invoice_action_to_sync</option_group_name>
             <description>Cancelled action to sync</description>
@@ -133,7 +133,7 @@
             <value>3</value>
             <is_default>0</is_default>
             <weight>3</weight>
-            <is_reserved>1</is_reserved>
+            <is_reserved>0</is_reserved>
             <is_active>1</is_active>
             <option_group_name>odoo_invoice_action_to_sync</option_group_name>
             <description>Failed action to sync</description>
@@ -144,7 +144,7 @@
             <value>4</value>
             <is_default>0</is_default>
             <weight>4</weight>
-            <is_reserved>1</is_reserved>
+            <is_reserved>0</is_reserved>
             <is_active>1</is_active>
             <option_group_name>odoo_invoice_action_to_sync</option_group_name>
             <description>Partially paid action to sync</description>
@@ -155,7 +155,7 @@
             <value>5</value>
             <is_default>0</is_default>
             <weight>5</weight>
-            <is_reserved>1</is_reserved>
+            <is_reserved>0</is_reserved>
             <is_active>1</is_active>
             <option_group_name>odoo_invoice_action_to_sync</option_group_name>
             <description>Completed action to sync</description>
@@ -166,7 +166,7 @@
             <value>6</value>
             <is_default>0</is_default>
             <weight>6</weight>
-            <is_reserved>1</is_reserved>
+            <is_reserved>0</is_reserved>
             <is_active>1</is_active>
             <option_group_name>odoo_invoice_action_to_sync</option_group_name>
             <description>Refunded action to sync</description>
@@ -183,7 +183,7 @@
             <is_active>1</is_active>
             <collapse_display>1</collapse_display>
             <collapse_adv_display>1</collapse_adv_display>
-            <is_reserved>1</is_reserved>
+            <is_reserved>0</is_reserved>
         </CustomGroup>
     </CustomGroups>
     <CustomFields>
@@ -324,7 +324,7 @@
             <is_active>1</is_active>
             <collapse_display>1</collapse_display>
             <collapse_adv_display>1</collapse_adv_display>
-            <is_reserved>1</is_reserved>
+            <is_reserved>0</is_reserved>
         </CustomGroup>
     </CustomGroups>
     <CustomFields>
@@ -452,7 +452,7 @@
             <is_active>1</is_active>
             <collapse_display>0</collapse_display>
             <collapse_adv_display>0</collapse_adv_display>
-            <is_reserved>1</is_reserved>
+            <is_reserved>0</is_reserved>
         </CustomGroup>
     </CustomGroups>
     <CustomFields>


### PR DESCRIPTION
1. Upon extension install the next custom fields are showing up under the Custom Data configuration page:
- Odoo Invoice Sync Information
- Odoo Partner Sync Information
- Purchase Order
![cos4_custom data](https://user-images.githubusercontent.com/36959503/37977693-f1a5d418-31ec-11e8-89bf-6d5b2974c9ec.png)

2. Upon extension disable the custom fields disable with a saving of schema.
![cos4_disable](https://user-images.githubusercontent.com/36959503/37977735-0c18ffd2-31ed-11e8-8b84-cf99da7d2d98.gif)

3. Upon extension enable the custom fields enable.
![cos4_enable](https://user-images.githubusercontent.com/36959503/37977759-1bf6a256-31ed-11e8-807b-50795dea074a.gif)
