### PR TITLE
COS-7: Fixing 'Save' for Contact inline-block forms

### DIFF
--- a/CRM/Odoosync/Hook/PostProcess/ContactSyncInformationUpdater.php
+++ b/CRM/Odoosync/Hook/PostProcess/ContactSyncInformationUpdater.php
@@ -108,7 +108,7 @@ class CRM_Odoosync_Hook_PostProcess_ContactSyncInformationUpdater {
    */
   private function setSyncAction() {
     $isInlineContactForm = preg_match('/^CRM_Contact_Form_Inline_/', $this->formName);
-    if ($isInlineContactForm && ($this->formgetAction() == CRM_Core_Action::UPDATE ||
+    if ($isInlineContactForm && ($this->form->getAction() == CRM_Core_Action::UPDATE ||
         CRM_Core_Action::ADD || CRM_Core_Action::DELETE)) {
       $this->syncAction = 'update';
     }


### PR DESCRIPTION
Upon Edit changes for Contact inline-block forms are saved.