### PR TITLE
COS-14: Adding Scheduled job "Sync CiviCRM changes to Odoo" and "CiviCRM Odoo Sync Error Report" message template mailing.

### DIFF
--- a/CRM/Odoosync/Mail/Error.php
+++ b/CRM/Odoosync/Mail/Error.php
@@ -1,0 +1,251 @@
+<?php
+
+/**
+ * This class sends error messages to emails from Odoo settings
+ */
+class CRM_Odoosync_Mail_Error {
+
+  /**
+   * Default domain email name
+   *
+   * @var array
+   */
+  const DEFAULT_DOMAIN_EMAIL_NAME = "CiviCRM";
+
+  /**
+   * Log messages
+   *
+   * @var array
+   */
+  private $log = [];
+
+  /**
+   * Recipients' emails use for send error messages
+   *
+   * @var array
+   */
+  private $emails = [];
+
+  /**
+   * Error message
+   *
+   * @var string
+   */
+  private $errorMessage;
+
+  /**
+   * Entity type
+   *
+   * @var string
+   */
+  private $entityType;
+
+  /**
+   * Entity id
+   *
+   * @var string
+   */
+  private $entityId;
+
+  /**
+   * Domain email name
+   *
+   * @var string
+   */
+  private $domainEmailName;
+
+  /**
+   * Domain email address
+   *
+   * @var string
+   */
+  private $domainEmailAddress;
+
+  /**
+   * CRM_Odoosync_Mail_Error constructor.
+   *
+   * @param $errorMessage
+   *
+   * @param $entityType
+   *
+   * @param $entityId
+   *
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Exception
+   */
+  public function __construct($errorMessage, $entityType, $entityId) {
+    $this->setEntityId($entityId);
+    $this->setEntityType($entityType);
+    $this->setErrorMessage($errorMessage);
+    $this->setEmails();
+    $this->setLog(ts("Found %1 recipients' emails.", [ 1 => count($this->emails)]));
+
+    list($domainEmailName, $domainEmailAddress) = CRM_Core_BAO_Domain::getNameAndEmail();
+    $this->setDomainEmailAddress($domainEmailAddress);
+    $this->setDomainEmailName($domainEmailName);
+  }
+
+  /**
+   * Sends sync error message email to the recipient
+   */
+  public function sendErrorMessage(){
+    foreach ($this->emails as $email) {
+      $this->sendToEmail($email);
+    }
+  }
+
+  /**
+   * Sends sync error message email to the recipient
+   *
+   * @param $email
+   */
+  private function sendToEmail($email) {
+    $this->setLog(ts('Sending to the %1 ...', [ 1 => $email]));
+
+    $param = [
+      'groupName' => 'msg_tpl_workflow_odoo_sync',
+      'valueName' => 'civicrm_odoo_sync_error_report',
+      'tplParams' =>
+        [
+          'errorMessage' => $this->getErrorMessage(),
+          'entityType' => $this->getEntityType(),
+          'entityId' => $this->getEntityId()
+        ],
+      'from' => $this->getDomainEmailName() . " <" . $this->getDomainEmailAddress() . ">",
+      'toEmail' => $email,
+    ];
+
+    list($sent, $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate($param);
+
+    if ($sent === TRUE) {
+      $this->setLog(ts('Success. Email was sent.'));
+    }
+    else {
+      $this->setLog(ts('Error. Email was not sent.'));
+    }
+  }
+
+  /**
+   * Sets emails from Odoo settings
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function setEmails() {
+    $emailFromSetting = civicrm_api3(
+      'setting',
+      'getsingle',
+      ['return' => ['odoosync_error_notice_address']]
+    );
+
+    if (!empty($emailFromSetting['odoosync_error_notice_address'])) {
+      $this->emails = explode(',', $emailFromSetting['odoosync_error_notice_address']);
+    }
+  }
+
+  /**
+   * Returns the log messages
+   *
+   * @return array
+   */
+  public function getReturnData() {
+    return [
+      'log' => $this->log
+    ];
+  }
+
+  /**
+   * @param mixed $log
+   */
+  public function setLog($log) {
+    $this->log[] = $log;
+  }
+
+  /**
+   * @param string $errorMessage
+   */
+  public function setErrorMessage($errorMessage) {
+    if (empty($errorMessage)) {
+      $this->errorMessage = '';
+    }
+
+    $this->errorMessage = $errorMessage;
+  }
+
+  /**
+   * @return string
+   */
+  public function getEntityType() {
+    return $this->entityType;
+  }
+
+  /**
+   * @param string $entityType
+   */
+  public function setEntityType($entityType) {
+    $this->entityType = $entityType;
+  }
+
+  /**
+   * @return string
+   */
+  public function getEntityId() {
+    return $this->entityId;
+  }
+
+  /**
+   * @param string $entityId
+   */
+  public function setEntityId($entityId) {
+    $this->entityId = $entityId;
+  }
+
+  /**
+   * @return string
+   */
+  public function getErrorMessage() {
+    return $this->errorMessage;
+  }
+
+  /**
+   * @return string
+   */
+  public function getDomainEmailName() {
+    return $this->domainEmailName;
+  }
+
+  /**
+   * If exist sets domain email name or sets default value
+   *
+   * @param string $domainEmailName
+   */
+  public function setDomainEmailName($domainEmailName) {
+    if (empty($domainEmailName)) {
+      $this->domainEmailName = self::DEFAULT_DOMAIN_EMAIL_NAME;
+    }
+    else {
+      $this->domainEmailName = $domainEmailName;
+    }
+  }
+
+  /**
+   * @return string
+   */
+  public function getDomainEmailAddress() {
+    return $this->domainEmailAddress;
+  }
+
+  /**
+   * If exist sets domain email address
+   *
+   * @param string $domainEmailAddress
+   */
+  public function setDomainEmailAddress($domainEmailAddress) {
+    if (empty($domainEmailAddress)) {
+      $this->domainEmailAddress = "";
+    }
+    else {
+      $this->domainEmailAddress = $domainEmailAddress;
+    }
+  }
+
+}

--- a/CRM/Odoosync/Upgrader.php
+++ b/CRM/Odoosync/Upgrader.php
@@ -33,8 +33,28 @@ class CRM_Odoosync_Upgrader extends CRM_Odoosync_Upgrader_Base {
    * @throws \CiviCRM_API3_Exception
    */
   public function install() {
-    $this->installScheduledJob();
+    $this->createScheduledJob();
     $this->createSyncErrorMessageTemplate();
+  }
+
+  /**
+   * Installs scheduled job
+   */
+  private function createScheduledJob() {
+    $domainID = CRM_Core_Config::domainID();
+
+    $params = [
+      'name' => 'Sync CiviCRM changes to Odoo',
+      'description' => 'Sync CiviCRM changes to Odoo',
+      'api_entity' => 'OdooSync',
+      'api_action' => 'run',
+      'run_frequency' => 'Hourly',
+      'domain_id' => $domainID,
+      'is_active' => '1',
+      'parameters' => ''
+    ];
+
+    CRM_Core_BAO_Job::create($params);
   }
 
   /**
@@ -140,17 +160,14 @@ class CRM_Odoosync_Upgrader extends CRM_Odoosync_Upgrader_Base {
 
   /**
    * Deletes scheduled job created by the extension
+   *
+   * @throws \CiviCRM_API3_Exception
    */
   private function deleteScheduledJob() {
-    $params = ['name' => 'Sync CiviCRM changes to Odoo'];
-    $defaults = [];
-    $scheduledJob = CRM_Core_BAO_Job::retrieve($params, $defaults);
-
-    if (empty($scheduledJob)) {
-      return;
-    }
-
-    CRM_Core_BAO_Job::del($scheduledJob->id);
+    civicrm_api3('Job', 'get', [
+      'name' => 'Sync CiviCRM changes to Odoo',
+      'api.Job.delete' => ['id' => '$value.id'],
+    ]);
   }
 
   /**
@@ -236,26 +253,6 @@ class CRM_Odoosync_Upgrader extends CRM_Odoosync_Upgrader_Base {
     ]);
 
     return (int) $id;
-  }
-
-  /**
-   * Installs scheduled job
-   */
-  private function installScheduledJob() {
-    $domainID = CRM_Core_Config::domainID();
-
-    $params = [
-      'name' => 'Sync CiviCRM changes to Odoo',
-      'description' => 'Sync CiviCRM changes to Odoo',
-      'api_entity' => 'OdooSync',
-      'api_action' => 'run',
-      'run_frequency' => 'Hourly',
-      'domain_id' => $domainID,
-      'is_active' => '1',
-      'parameters' => ''
-    ];
-
-    CRM_Core_BAO_Job::create($params);
   }
 
   /**

--- a/CRM/Odoosync/Upgrader.php
+++ b/CRM/Odoosync/Upgrader.php
@@ -33,6 +33,7 @@ class CRM_Odoosync_Upgrader extends CRM_Odoosync_Upgrader_Base {
    * @throws \CiviCRM_API3_Exception
    */
   public function install() {
+    $this->installScheduledJob();
     $this->createSyncErrorMessageTemplate();
   }
 
@@ -69,6 +70,7 @@ class CRM_Odoosync_Upgrader extends CRM_Odoosync_Upgrader_Base {
    * @throws \CiviCRM_API3_Exception
    */
   public function uninstall() {
+    $this->deleteScheduledJob();
     $this->deleteSyncErrorMessageTemplate();
     $this->deleteExtensionOptionGroups();
     $this->deleteExtensionCustomGroups();
@@ -134,6 +136,21 @@ class CRM_Odoosync_Upgrader extends CRM_Odoosync_Upgrader_Base {
       'name' => $customGroupName,
       'api.CustomGroup.delete' => ['id' => '$value.id'],
     ]);
+  }
+
+  /**
+   * Deletes scheduled job created by the extension
+   */
+  private function deleteScheduledJob() {
+    $params = ['name' => 'Sync CiviCRM changes to Odoo'];
+    $defaults = [];
+    $scheduledJob = CRM_Core_BAO_Job::retrieve($params, $defaults);
+
+    if (empty($scheduledJob)) {
+      return;
+    }
+
+    CRM_Core_BAO_Job::del($scheduledJob->id);
   }
 
   /**
@@ -219,6 +236,26 @@ class CRM_Odoosync_Upgrader extends CRM_Odoosync_Upgrader_Base {
     ]);
 
     return (int) $id;
+  }
+
+  /**
+   * Installs scheduled job
+   */
+  private function installScheduledJob() {
+    $domainID = CRM_Core_Config::domainID();
+
+    $params = [
+      'name' => 'Sync CiviCRM changes to Odoo',
+      'description' => 'Sync CiviCRM changes to Odoo',
+      'api_entity' => 'OdooSync',
+      'api_action' => 'run',
+      'run_frequency' => 'Hourly',
+      'domain_id' => $domainID,
+      'is_active' => '1',
+      'parameters' => ''
+    ];
+
+    CRM_Core_BAO_Job::create($params);
   }
 
   /**

--- a/api/v3/OdooSync.php
+++ b/api/v3/OdooSync.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * This api calls when run schedule job "Sync CiviCRM changes to Odoo"
+ * This API get called when run schedule job "Sync CiviCRM changes to Odoo"
  *
  * @param $params
  *
@@ -9,20 +9,22 @@
  */
 function civicrm_api3_odoo_sync_run($params) {
   //TODO in next COS
+
   return TRUE;
 }
 
 /**
- * This api for odoo send error message
+ * This API is used for sending Odoo error message
  *
  * @param $params
  *
  * @return mixed
  */
 function civicrm_api3_odoo_sync_send_error_message($params) {
-  $errorMail = new CRM_Odoosync_Mail_Error($params['error_message'], $params['entity_type'], $params['entity_id']);
-  $errorMail->sendErrorMessage();
-  return $errorMail->getReturnData();
+  $errorMail = new CRM_Odoosync_Mail_Error($params['entity_id'], $params['entity_type'], $params['error_message']);
+  $log = $errorMail->sendToRecipients();
+
+  return $log;
 }
 
 /**

--- a/api/v3/OdooSync.php
+++ b/api/v3/OdooSync.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * This api calls when run schedule job "Sync CiviCRM changes to Odoo"
+ *
+ * @param $params
+ *
+ * @return bool
+ */
+function civicrm_api3_odoo_sync_run($params) {
+  //TODO in next COS
+  return TRUE;
+}

--- a/api/v3/OdooSync.php
+++ b/api/v3/OdooSync.php
@@ -11,3 +11,28 @@ function civicrm_api3_odoo_sync_run($params) {
   //TODO in next COS
   return TRUE;
 }
+
+/**
+ * This api for odoo send error message
+ *
+ * @param $params
+ *
+ * @return mixed
+ */
+function civicrm_api3_odoo_sync_send_error_message($params) {
+  $errorMail = new CRM_Odoosync_Mail_Error($params['error_message'], $params['entity_type'], $params['entity_id']);
+  $errorMail->sendErrorMessage();
+  return $errorMail->getReturnData();
+}
+
+/**
+ * Adjust Metadata for "send_error_message" action
+ *
+ * The metadata is used for setting defaults, documentation & validation
+ * @param array $params array or parameters determined by getfields
+ */
+function _civicrm_api3_odoo_sync_send_error_message_spec(&$params) {
+  $params['error_message']['api.required'] = 1;
+  $params['entity_type']['api.required'] = 1;
+  $params['entity_id']['api.required'] = 1;
+}

--- a/templates/CRM/Odoosync/DefaultMessageTemplates/OdooSyncErrorReport.html
+++ b/templates/CRM/Odoosync/DefaultMessageTemplates/OdooSyncErrorReport.html
@@ -2,6 +2,21 @@
     <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <body>
-        <h2>CiviCRM Odoo Sync Error Report</h2>
+        <h2>{ts}CiviCRM Odoo Sync Error Report{/ts}</h2>
+        <br/>
+        <table>
+            <tr>
+                <td><p>{ts}Entity type:{/ts}</p></td>
+                <td><p>{$entityType}</p></td>
+            </tr>
+            <tr>
+                <td><p>{ts}Entity id:{/ts}</p></td>
+                <td><p>{$entityId}</p></td>
+            </tr>
+            <tr>
+                <td><p>{ts}Error log:{/ts}</p></td>
+                <td><p>{$errorMessage}</p></td>
+            </tr>
+        </table>
     </body>
 </html>


### PR DESCRIPTION
1. The extension creates a new scheduled job "Sync CiviCRM changes to Odoo". With the "Hourly" default frequency of the job.
![cos - 14 scheduled job](https://user-images.githubusercontent.com/36959503/38317022-c1ea8f36-3834-11e8-9082-7c0b22e2116f.gif)

2. Every time the "Sync CiviCRM changes to Odoo" job is run, the job process run through the following records in order (will be fully realized with the next tickets)
- "Organisation" contacts whose Sync Status is "Awaiting sync"
- "Individual" contacts whose Sync Status is "Awaiting sync"
- Contributions whose Sync Status is "Awaiting sync"

3. At the end of the job run, if any of the record sync had an error and reached the "Retry Threshold", an email "CiviCRM Odoo Sync Error Report" message template sends to the email addresses defined in "Error Notice Address" setting. The email contains the following information for each record that has the "Sync Status" field marked as "Sync failed":
- entity type: contact/ contribution
- entity id
- error log
![cos-14 error message](https://user-images.githubusercontent.com/36959503/38317083-e36aca40-3834-11e8-9834-3bc31b2f7531.gif)

