### PR TITLE
Fixes for: ‘Retry Count' work on every failed Sync and the message send on email when Contact 'Retry Threshold' is reached;Mapping changes applying; Timestamp 'View' for Contact 'Odoo Partner Sync Information';

### DIFF
--- a/CRM/Odoosync/Sync/Contact.php
+++ b/CRM/Odoosync/Sync/Contact.php
@@ -20,19 +20,18 @@ class CRM_Odoosync_Sync_Contact extends CRM_Odoosync_Sync_BaseHandler {
   protected function startSync() {
     $this->setLog(ts('Start Contacts Syncing ...'));
     $this->setJobLog(ts('Start Contacts Syncing ...'));
+    
+    $pendingContacts = new CRM_Odoosync_Sync_Contact_PendingContacts();
+    $contactIdList = $pendingContacts->getPendingContacts();
 
-    $batchSize = (int) $this->setting['odoosync_batch_size'];
-    $pendingContactsFetcher = new CRM_Odoosync_Sync_Contact_PendingContactsFetcher();
+    if (empty($contactIdList)) {
+      $this->setJobLog(ts('All contact is sync'));
+      $this->setLog(ts('All contact is sync'));
+      return $this->getDebuggingData();
+    }
 
-    for ($i = 0; $i < $batchSize; $i++) {
-      $this->syncContactId = $pendingContactsFetcher->getPendingContact();
-
-      if (empty($this->syncContactId)) {
-        $this->setJobLog(ts('All contact is sync'));
-        $this->setLog(ts('All contact is sync'));
-        return $this->getDebuggingData();
-      }
-
+    foreach ($contactIdList as $contactId) {
+      $this->syncContactId = $contactId;
       $this->syncContact();
     }
 

--- a/CRM/Odoosync/Sync/Contact/Data/Address.php
+++ b/CRM/Odoosync/Sync/Contact/Data/Address.php
@@ -83,23 +83,27 @@ class CRM_Odoosync_Sync_Contact_Data_Address extends CRM_Odoosync_Sync_Contact_D
    * @return string
    */
   private function generateSupplementalAddress($address) {
-    $supplementalAddress = '';
+    $addressList = [];
 
     if (!empty($address['supplemental_address_1'])) {
-      $supplementalAddress .= $address['supplemental_address_1'] . ';';
+      $addressList[] = trim(str_replace(',', ' ', $address['supplemental_address_1']));
     }
 
     if (!empty($address['supplemental_address_2'])) {
-      $supplementalAddress .= $address['supplemental_address_2'] . ';';
+      $addressList[] = trim(str_replace(',', ' ', $address['supplemental_address_2']));
     }
 
     if (!empty($address['supplemental_address_3'])) {
-      $supplementalAddress .= $address['supplemental_address_3'] . ';';
+      $addressList[] = trim(str_replace(',', ' ', $address['supplemental_address_3']));
     }
 
     if (!empty($address['state_province_id'])) {
-      $supplementalAddress .= CRM_Core_PseudoConstant::stateProvince($address['state_province_id']) . ';';
+      $addressList[] = trim(
+        str_replace(',', ' ', CRM_Core_PseudoConstant::stateProvince($address['state_province_id']))
+      );
     }
+
+    $supplementalAddress = implode(', ', $addressList);
 
     return $supplementalAddress;
   }

--- a/CRM/Odoosync/Sync/Contact/Data/Website.php
+++ b/CRM/Odoosync/Sync/Contact/Data/Website.php
@@ -32,6 +32,7 @@ class CRM_Odoosync_Sync_Contact_Data_Website extends CRM_Odoosync_Sync_Contact_D
   private function getWebsiteURL($additionalParams = []) {
     $defaultParams = [
       'return' => 'url',
+      'options' => ['limit' => 1],
       'contact_id' => $this->contactId,
       ];
     $params = array_merge($defaultParams, $additionalParams);

--- a/CRM/Odoosync/Sync/Contact/PendingContacts.php
+++ b/CRM/Odoosync/Sync/Contact/PendingContacts.php
@@ -1,9 +1,9 @@
 <?php
 
 /**
- * Gets appropriate contact for synchronization with Odoo
+ * Gets appropriate contacts for synchronization with Odoo
  */
-class CRM_Odoosync_Sync_Contact_PendingContactsFetcher {
+class CRM_Odoosync_Sync_Contact_PendingContacts {
 
   /**
    * Sync contact id
@@ -30,22 +30,30 @@ class CRM_Odoosync_Sync_Contact_PendingContactsFetcher {
   }
 
   /**
-   * Gets first not synchronized contact's id
+   * Gets first not synchronized contact's ids
    *
-   * @return int|null
+   * @return array
    */
-  public function getPendingContact() {
+  public function getPendingContacts() {
+    $syncSetting = CRM_Odoosync_Setting::getInstance()->retrieve();
+
     try {
-      $contact = civicrm_api3('Contact', 'getsingle', [
+      $contacts = civicrm_api3('Contact', 'get', [
         'return' => ["id"],
-        'options' => ['limit' => 1],
+        'is_deleted' =>['IS NOT NULL' => 1],
+        'options' => ['limit' => (int) $syncSetting['odoosync_batch_size']],
         'custom_' . $this->syncStatusFieldId => $this->syncStatusValue,
       ]);
 
-      return (int) $contact['id'];
+      $contactListId = [];
+      foreach ($contacts['values'] as $contact) {
+        $contactListId[] = $contact['contact_id'];
+      }
+
+      return $contactListId;
     }
     catch (CiviCRM_API3_Exception $e) {
-      return NULL;
+      return [];
     }
   }
 

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -206,6 +206,7 @@
             <data_type>Date</data_type>
             <html_type>Select Date</html_type>
             <date_format>mm/dd/yy</date_format>
+            <time_format>2</time_format>
             <is_searchable>1</is_searchable>
             <is_view>1</is_view>
             <is_required>0</is_required>
@@ -276,6 +277,7 @@
             <data_type>Date</data_type>
             <html_type>Select Date</html_type>
             <date_format>mm/dd/yy</date_format>
+            <time_format>2</time_format>
             <is_searchable>1</is_searchable>
             <is_view>1</is_view>
             <is_required>0</is_required>
@@ -290,6 +292,7 @@
             <data_type>Date</data_type>
             <html_type>Select Date</html_type>
             <date_format>mm/dd/yy</date_format>
+            <time_format>2</time_format>
             <is_searchable>1</is_searchable>
             <is_view>1</is_view>
             <is_required>0</is_required>
@@ -347,6 +350,7 @@
             <data_type>Date</data_type>
             <html_type>Select Date</html_type>
             <date_format>mm/dd/yy</date_format>
+            <time_format>2</time_format>
             <is_searchable>1</is_searchable>
             <is_view>1</is_view>
             <is_required>0</is_required>
@@ -404,6 +408,7 @@
             <data_type>Date</data_type>
             <html_type>Select Date</html_type>
             <date_format>mm/dd/yy</date_format>
+            <time_format>2</time_format>
             <is_searchable>1</is_searchable>
             <is_view>1</is_view>
             <is_required>0</is_required>
@@ -418,6 +423,7 @@
             <data_type>Date</data_type>
             <html_type>Select Date</html_type>
             <date_format>mm/dd/yy</date_format>
+            <time_format>2</time_format>
             <is_searchable>1</is_searchable>
             <is_view>1</is_view>
             <is_required>0</is_required>


### PR DESCRIPTION
COS-14: ‘Retry Count' work on every failed Sync and the message send on email when Contact 'Retry Threshold' is reached.
1. First fail Scheduled job run gives ‘1’ to ‘Retry Count’ of Contact.
2. The message send on email when ‘Retry Threshold’ is reached for Contact ‘Retry Count’.
![cos-14-fix-retry count](https://user-images.githubusercontent.com/36959503/39635933-83f46dfa-4fc7-11e8-899f-1bdc31237207.gif)


COS-15: Mapping changes applying
1. In API call for Contact:
- Concatenate addresses with "comma" (", " ) when there is no "comma" entered in the CiviCRM address fields.
![cos-15-addresses](https://user-images.githubusercontent.com/36959503/39636108-f1236318-4fc7-11e8-8099-7df8d2516f95.gif)


- Do not concatenate with "comma" (", " ) when there is "comma" entered in the CiviCRM address fields.
2. In API call for Contact:
- If there are two websites of type "Main" first of those two is synced.
![cos-15-website](https://user-images.githubusercontent.com/36959503/39636171-1fe172e4-4fc8-11e8-8f7c-e99f26fe4320.gif)


3. After Sync of deleted Contact in CiviCRM (previously created in Odoo) it becomes Inactive in Odoo too.
![cos-15-contact delete](https://user-images.githubusercontent.com/36959503/39636207-3964ed68-4fc8-11e8-9d3c-ba916d63b7e0.gif)


COS-16: Timestamp ‘View’ for Contact ‘Odoo Partner Sync Information’.
When ‘View’ Contact ‘Odoo Partner Sync Information’ fields. ‘05/04/2018 16:56’ Timestamp is used for these fields.
![cos-16-timestamp](https://user-images.githubusercontent.com/36959503/39636253-5c91cb80-4fc8-11e8-990b-983b1ac18049.gif)
