### PR TITLE
COS-14: 'Retry Count' work on every failed Sync and the message send on email when Contact 'Retry Threshold' is reached.

### DIFF
--- a/CRM/Odoosync/Sync/Contact.php
+++ b/CRM/Odoosync/Sync/Contact.php
@@ -21,18 +21,17 @@ class CRM_Odoosync_Sync_Contact extends CRM_Odoosync_Sync_BaseHandler {
     $this->setLog(ts('Start Contacts Syncing ...'));
     $this->setJobLog(ts('Start Contacts Syncing ...'));
 
-    $batchSize = (int) $this->setting['odoosync_batch_size'];
-    $pendingContactsFetcher = new CRM_Odoosync_Sync_Contact_PendingContactsFetcher();
+    $pendingContacts = new CRM_Odoosync_Sync_Contact_PendingContacts();
+    $contactIdList = $pendingContacts->getPendingContacts();
 
-    for ($i = 0; $i < $batchSize; $i++) {
-      $this->syncContactId = $pendingContactsFetcher->getPendingContact();
+    if (empty($contactIdList)) {
+      $this->setJobLog(ts('All contact is sync'));
+      $this->setLog(ts('All contact is sync'));
+      return $this->getDebuggingData();
+    }
 
-      if (empty($this->syncContactId)) {
-        $this->setJobLog(ts('All contact is sync'));
-        $this->setLog(ts('All contact is sync'));
-        return $this->getDebuggingData();
-      }
-
+    foreach ($contactIdList as $contactId) {
+      $this->syncContactId = $contactId;
       $this->syncContact();
     }
 


### PR DESCRIPTION
1. First fail Scheduled job run gives ‘1’ to ‘Retry Count’ of Contact.
2. The message send on email when ‘Retry Threshold’ is reached for Contact ‘Retry Count’.

![cos-14-fix-retry count](https://user-images.githubusercontent.com/36959503/39707020-d74bb91c-521b-11e8-8de2-ba84f1b27923.gif)
