### PR TITLE
COS-20: Adding contributions syncing support

### DIFF
--- a/CRM/Odoosync/Common/CustomField.php
+++ b/CRM/Odoosync/Common/CustomField.php
@@ -1,0 +1,27 @@
+<?php
+
+
+class CRM_Odoosync_Common_CustomField {
+
+  /**
+   * Gets custom field id
+   *
+   * @param $customGroupName
+   * @param $customFieldName
+   *
+   * @return int
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function getCustomFieldId($customGroupName, $customFieldName) {
+    $customFieldId = civicrm_api3('CustomField', 'getvalue', [
+      'sequential' => 1,
+      'options' => ['limit' => 1],
+      'return' => "id",
+      'name' => $customFieldName,
+      'custom_group_id' => $customGroupName,
+    ]);
+
+    return (int) $customFieldId;
+  }
+
+}

--- a/CRM/Odoosync/Common/Date.php
+++ b/CRM/Odoosync/Common/Date.php
@@ -1,0 +1,20 @@
+<?php
+
+class CRM_Odoosync_Common_Date {
+
+  /**
+   * Converts date into timestamp
+   * In default use MySQL date format('Y-m-d H:i:s')
+   *
+   * @param $mysqlDate
+   * @param string $inputDateFormat
+   *
+   * @return int
+   */
+  public static function convertDateToTimestamp($mysqlDate, $inputDateFormat = 'Y-m-d H:i:s') {
+    $date = DateTime::createFromFormat($inputDateFormat, $mysqlDate);
+
+    return ($date) ? $date->getTimestamp() : 0;
+  }
+
+}

--- a/CRM/Odoosync/Common/OptionValue.php
+++ b/CRM/Odoosync/Common/OptionValue.php
@@ -24,4 +24,26 @@ class CRM_Odoosync_Common_OptionValue {
     return $optionValue['value'];
   }
 
+  /**
+   * Gets the 'option value' name
+   * for the specified option group and option value ID (value)
+   *
+   * @param $optionGroupName
+   * @param $valueId
+   *
+   * @return string
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function getOptionName($optionGroupName, $valueId) {
+    $optionName = civicrm_api3('OptionValue', 'getvalue', [
+      'sequential' => 1,
+      'return' => "name",
+      'option_group_id' => $optionGroupName,
+      'value' => $valueId,
+      'options' => ['limit' => 1]
+    ]);
+
+    return $optionName;
+  }
+
 }

--- a/CRM/Odoosync/Sync.php
+++ b/CRM/Odoosync/Sync.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Main boot point for Odoo sync
+ */
+class CRM_Odoosync_Sync {
+
+  /**
+   * Runs Odoo sync
+   *
+   * @param $params
+   *
+   * @return array
+   * @throws \Exception
+   */
+  public function run($params) {
+    $log = [];
+    $logContact = (new CRM_Odoosync_Sync_Contact($params))->run();
+    $logContribution = (new CRM_Odoosync_Sync_Contribution($params))->run();
+
+    $log['is_error'] = ($logContact['is_error'] == 1 || $logContact['is_error'] == 1) ? 1 : 0;
+
+    //more detail log can view in api when debug = 1
+    if ($params['debug'] == 1) {
+      $log['debugLog']['contacts_debug_log'] = $logContact['debugLog'];
+      $log['debugLog']['contribution_debug_log'] = $logContribution['debugLog'];
+    }
+
+    //this log can view on schedule job
+    $log['values'] = '<br/>' . $logContact['values'] . $logContribution['values'];
+
+    return $log;
+  }
+
+}

--- a/CRM/Odoosync/Sync/Contact.php
+++ b/CRM/Odoosync/Sync/Contact.php
@@ -20,7 +20,7 @@ class CRM_Odoosync_Sync_Contact extends CRM_Odoosync_Sync_BaseHandler {
   protected function startSync() {
     $this->setLog(ts('Start Contacts Syncing ...'));
     $this->setJobLog(ts('Start Contacts Syncing ...'));
-
+    
     $pendingContacts = new CRM_Odoosync_Sync_Contact_PendingContacts();
     $contactIdList = $pendingContacts->getPendingContacts();
 
@@ -90,8 +90,8 @@ class CRM_Odoosync_Sync_Contact extends CRM_Odoosync_Sync_BaseHandler {
         ]
       )
     );
-    $syncInformation = new CRM_Odoosync_Sync_Contact_ResponseHandler();
-    $syncInformation->handleSuccess($partnerId, $this->syncContactId);
+    $responseHandler = new CRM_Odoosync_Sync_Contact_ResponseHandler();
+    $responseHandler->handleSuccess($partnerId, $this->syncContactId);
     $this->setLog(ts('Successful sync. Contact data updated.'));
   }
 
@@ -105,8 +105,8 @@ class CRM_Odoosync_Sync_Contact extends CRM_Odoosync_Sync_BaseHandler {
   private function handleErrorResponse($errorMessage) {
     $this->setJobLog(ts('Sync with error. Contact id = %1.', [1 => $this->syncContactId]));
 
-    $syncInformation = new CRM_Odoosync_Sync_Contact_ResponseHandler();
-    $isReachedRetryThreshold = $syncInformation->handleError(
+    $responseHandler = new CRM_Odoosync_Sync_Contact_ResponseHandler();
+    $isReachedRetryThreshold = $responseHandler->handleError(
       $errorMessage,
       $this->setting['odoosync_retry_threshold'],
       $this->syncContactId

--- a/CRM/Odoosync/Sync/Contact/InformationGenerator.php
+++ b/CRM/Odoosync/Sync/Contact/InformationGenerator.php
@@ -123,10 +123,10 @@ class CRM_Odoosync_Sync_Contact_InformationGenerator {
   private function generateDateFields() {
     $contactDate = CRM_Contact_BAO_Contact::getTimestamps($this->contactId);
     if (!empty($contactDate['modified_date'])) {
-      $this->fieldsToGenerate['write_date'] = $this->convertDateToTimestamp($contactDate['modified_date']);
+      $this->fieldsToGenerate['write_date'] = CRM_Odoosync_Common_Date::convertDateToTimestamp($contactDate['modified_date']);
     }
     if (!empty($contactDate['created_date'])) {
-      $this->fieldsToGenerate['create_date'] = $this->convertDateToTimestamp($contactDate['created_date']);
+      $this->fieldsToGenerate['create_date'] = CRM_Odoosync_Common_Date::convertDateToTimestamp($contactDate['created_date']);
     }
   }
 
@@ -159,18 +159,6 @@ class CRM_Odoosync_Sync_Contact_InformationGenerator {
     }
 
     return $prefixName;
-  }
-
-  /**
-   * Converts MySQL date format into timestamp
-   *
-   * @param $mysqlDate
-   *
-   * @return int
-   */
-  public function convertDateToTimestamp($mysqlDate) {
-    $date = DateTime::createFromFormat('Y-m-d H:i:s', $mysqlDate);
-    return $date->getTimestamp();
   }
 
   /**

--- a/CRM/Odoosync/Sync/Contribution.php
+++ b/CRM/Odoosync/Sync/Contribution.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Handles syncing contribution data to odoo
+ */
+class CRM_Odoosync_Sync_Contribution extends CRM_Odoosync_Sync_BaseHandler {
+
+  /**
+   * The contribution ID to sync
+   *
+   * @var int
+   */
+  private $syncContributionId;
+
+  /**
+   * Starts contribution Odoo sync
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function startSync() {
+    $this->setLog(ts('Start Contribution Syncing ...'));
+    $this->setJobLog(ts('Start Contribution Syncing ...'));
+
+    $pendingContribution = new CRM_Odoosync_Sync_Contribution_PendingContribution();
+    $contributionIdList = $pendingContribution->getPendingContributions();
+
+    if (empty($contributionIdList)) {
+      $this->setJobLog(ts('All Contributions are synced'));
+      $this->setLog(ts('All Contributions are synced'));
+      return $this->getDebuggingData();
+    }
+
+    foreach ($contributionIdList as $contributionId) {
+      $this->syncContributionId = $contributionId;
+      $this->syncContribution();
+    }
+
+    return $this->getDebuggingData();
+  }
+
+  /**
+   * Syncs single contribution
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function syncContribution() {
+    $sendData = (new CRM_Odoosync_Sync_Contribution_InformationGenerator($this->syncContributionId))->generate();
+    $this->setLog(ts("Prepare contribution(id = %1) to sync", [1 => $this->syncContributionId]));
+    $this->setLog(ts("Contribution data:"));
+    $this->setLog($sendData);
+    $syncResponse = (new CRM_Odoosync_Sync_Request_Contribution())->sync($sendData);
+    $this->handleResponse($syncResponse);
+  }
+
+  /**
+   * Handles Odoo API response and updates contribution sync information
+   *
+   * @param $syncResponse
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function handleResponse($syncResponse) {
+    $this->setLog(ts('Odoo response:'));
+    $this->setLog($syncResponse);
+
+    if ($syncResponse['is_error'] == 0) {
+      $this->handleSuccessResponse(
+        $syncResponse['creditnote_number'],
+        $syncResponse['invoice_number'],
+        $syncResponse['timestamp']
+      );
+    }
+    else {
+      $this->handleErrorResponse($syncResponse['error_message'], $syncResponse['timestamp']);
+    }
+
+    $this->setLog(ts('End sync Contribution.'));
+  }
+
+  /**
+   * Handles success response
+   *
+   * @param $creditNoteNumber
+   * @param $invoiceNumber
+   * @param $timestamp
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function handleSuccessResponse($creditNoteNumber, $invoiceNumber, $timestamp) {
+    $this->setJobLog(ts('Sync with success. Contribution id = %1.', [1 => $this->syncContributionId]));
+    //TODO: in COS-21
+  }
+
+  /**
+   * Handles error response
+   *
+   * @param string $errorMessage
+   * @param $timestamp
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function handleErrorResponse($errorMessage, $timestamp) {
+    $this->setJobLog(ts('Sync with error. Contribution id = %1.', [1 => $this->syncContributionId]));
+    //TODO: in COS-21
+  }
+
+}

--- a/CRM/Odoosync/Sync/Contribution.php
+++ b/CRM/Odoosync/Sync/Contribution.php
@@ -22,7 +22,7 @@ class CRM_Odoosync_Sync_Contribution extends CRM_Odoosync_Sync_BaseHandler {
     $this->setJobLog(ts('Start Contribution Syncing ...'));
 
     $pendingContribution = new CRM_Odoosync_Sync_Contribution_PendingContribution();
-    $contributionIdList = $pendingContribution->getPendingContributions();
+    $contributionIdList = $pendingContribution->getIds();
 
     if (empty($contributionIdList)) {
       $this->setJobLog(ts('All Contributions are synced'));

--- a/CRM/Odoosync/Sync/Contribution/Data.php
+++ b/CRM/Odoosync/Sync/Contribution/Data.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Abstraction class provides skeleton for each part of contribution information
+ */
+abstract class CRM_Odoosync_Sync_Contribution_Data {
+
+  /**
+   * Sync contribution id
+   *
+   * @var int
+   */
+  protected $contributionId;
+
+  /**
+   * @param int $contributionId
+   */
+  public function __construct($contributionId) {
+    $this->contributionId = $contributionId;
+  }
+
+  /**
+   * Returns contribution data
+   *
+   * @return mixed
+   */
+  abstract public function retrieve();
+
+}

--- a/CRM/Odoosync/Sync/Contribution/Data/AccountRelationShip.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/AccountRelationShip.php
@@ -1,0 +1,74 @@
+<?php
+
+class CRM_Odoosync_Sync_Contribution_Data_AccountRelationShip {
+
+  /**
+   * Relationship ID for Income Account
+   *
+   * @return NULL|int
+   */
+  private static $incomeAccountRelationshipId = NULL;
+
+  /**
+   * Relationship ID for Accounts Receivable Account
+   *
+   * @return NULL|int
+   */
+  private static $accountsReceivableAccountRelationshipId = NULL;
+
+  /**
+   * Relationship ID for Sales Tax Account
+   *
+   * @return NULL|int
+   */
+  private static $salesTaxAccountRelationshipId = NULL;
+
+  /**
+   * Gets relationship ID for Income Account
+   *
+   * @return string
+   */
+  public static function getIncomeAccountRelationshipId() {
+    if (is_null(self::$incomeAccountRelationshipId)) {
+      self::$incomeAccountRelationshipId = CRM_Odoosync_Common_OptionValue::getOptionValueID(
+        'account_relationship',
+        'Income Account is'
+      );
+    }
+
+    return self::$incomeAccountRelationshipId;
+  }
+
+  /**
+   * Gets relationship ID for Accounts Receivable Account
+   *
+   * @return string
+   */
+  public static function getAccountsReceivableAccountRelationshipId() {
+    if (is_null(self::$accountsReceivableAccountRelationshipId)) {
+      self::$accountsReceivableAccountRelationshipId = CRM_Odoosync_Common_OptionValue::getOptionValueID(
+        'account_relationship',
+        'Accounts Receivable Account is'
+      );
+    }
+
+    return self::$accountsReceivableAccountRelationshipId;
+  }
+
+  /**
+   * Gets relationship ID for Accounts Receivable Account
+   *
+   * @return string
+   */
+  public static function getSalesTaxAccountRelationshipId() {
+    if (is_null(self::$salesTaxAccountRelationshipId)) {
+      self::$salesTaxAccountRelationshipId = CRM_Odoosync_Common_OptionValue::getOptionValueID(
+        'account_relationship',
+        'Sales Tax Account is'
+      );
+    }
+
+    return self::$salesTaxAccountRelationshipId;
+  }
+
+}

--- a/CRM/Odoosync/Sync/Contribution/Data/AccountRelationShip.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/AccountRelationShip.php
@@ -28,7 +28,7 @@ class CRM_Odoosync_Sync_Contribution_Data_AccountRelationShip {
    *
    * @return string
    */
-  public static function getIncomeAccountRelationshipId() {
+  public static function getIncomeAccountId() {
     if (is_null(self::$incomeAccountRelationshipId)) {
       self::$incomeAccountRelationshipId = CRM_Odoosync_Common_OptionValue::getOptionValueID(
         'account_relationship',
@@ -44,7 +44,7 @@ class CRM_Odoosync_Sync_Contribution_Data_AccountRelationShip {
    *
    * @return string
    */
-  public static function getAccountsReceivableAccountRelationshipId() {
+  public static function getAccountsReceivableId() {
     if (is_null(self::$accountsReceivableAccountRelationshipId)) {
       self::$accountsReceivableAccountRelationshipId = CRM_Odoosync_Common_OptionValue::getOptionValueID(
         'account_relationship',
@@ -60,7 +60,7 @@ class CRM_Odoosync_Sync_Contribution_Data_AccountRelationShip {
    *
    * @return string
    */
-  public static function getSalesTaxAccountRelationshipId() {
+  public static function getSalesTaxAccountId() {
     if (is_null(self::$salesTaxAccountRelationshipId)) {
       self::$salesTaxAccountRelationshipId = CRM_Odoosync_Common_OptionValue::getOptionValueID(
         'account_relationship',

--- a/CRM/Odoosync/Sync/Contribution/Data/ContributionParam.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/ContributionParam.php
@@ -1,0 +1,160 @@
+<?php
+
+class CRM_Odoosync_Sync_Contribution_Data_ContributionParam extends CRM_Odoosync_Sync_Contribution_Data {
+
+  /**
+   * Account relationship id
+   *
+   * @var int
+   */
+  const ACCOUNT_RELATIONSHIP_ID = 3;
+
+  /**
+   * Gets the contribution's params
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function retrieve() {
+    $contributionData = $this->getContributionData();
+    $actionToSyncValueId = $contributionData->action_to_sync;
+    $actionDateTimestamp = $this->getActionDateTimestamp($contributionData->action_date);
+    $receiveDateTimestamp = $this->getActionDateTimestamp($contributionData->receive_date);
+    $actionToSyncName = CRM_Odoosync_Common_OptionValue::getOptionName(
+      'odoo_invoice_action_to_sync',
+      $actionToSyncValueId
+    );
+    $contactId = $contributionData->contact_id;
+    $purchaseOrderNumber = $contributionData->purchase_order_number;
+    $accountCode = $this->getAccountCode();
+    $currencyCode = $contributionData->currency;
+
+    $contributionParams = [
+      [
+        'name' => 'journal_code',
+        'type' => 'string',
+        'value' => ''
+      ],
+      [
+        'name' => 'name',
+        'type' => 'string',
+        'value' => $purchaseOrderNumber
+      ],
+      [
+        'name' => 'currency_code',
+        'type' => 'string',
+        'value' => $currencyCode
+      ],
+      [
+        'name' => 'account_code',
+        'type' => 'int',
+        'value' => $accountCode
+      ],
+      [
+        'name' => 'x_civicrm_id',
+        'type' => 'int',
+        'value' => $this->contributionId
+      ],
+      [
+        'name' => 'contact_civicrm_id',
+        'type' => 'int',
+        'value' => $contactId
+      ],
+      [
+        'name' => 'receive_date',
+        'type' => 'int',
+        'value' => $receiveDateTimestamp
+      ],
+      [
+        'name' => 'action_to_sync',
+        'type' => 'string',
+        'value' => $actionToSyncName
+      ],
+      [
+        'name' => 'action_date',
+        'type' => 'int',
+        'value' => $actionDateTimestamp
+      ]
+    ];
+
+    return $contributionParams;
+  }
+
+  /**
+   * Gets timestamp 'action date'
+   *
+   * @param $actionDate
+   *
+   * @return int
+   */
+  private function getActionDateTimestamp($actionDate) {
+    if (!empty($actionDate)) {
+      return CRM_Odoosync_Common_Date::convertDateToTimestamp($actionDate);
+    }
+
+    return 0;
+  }
+
+  /**
+   * Gets the contribution's data
+   *
+   * @return null|object
+   */
+  private function getContributionData() {
+    $query = "
+      SELECT 
+        contribution.currency AS currency,
+        contribution.contact_id AS contact_id,
+        purchase_order.purchase_order_number AS purchase_order_number,
+        sync_info.action_to_sync AS action_to_sync, 
+        sync_info.action_date AS action_date,
+        contribution.receive_date AS receive_date
+      FROM civicrm_contribution AS contribution
+      LEFT JOIN purchase_order 
+        ON contribution.id = purchase_order.entity_id
+      LEFT JOIN odoo_invoice_sync_information AS sync_info 
+        ON contribution.id = sync_info.entity_id                
+      WHERE contribution.id = %1
+      LIMIT 1
+    ";
+
+    $dao = CRM_Core_DAO::executeQuery($query, [1 => [$this->contributionId, 'Integer']]);
+
+    while ($dao->fetch()) {
+      return $dao;
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Gets account code
+   *
+   * @return int
+   */
+  public function getAccountCode() {
+    $query = "
+      SELECT financial_account.accounting_code AS account_code
+      FROM civicrm_entity_financial_account AS entity_financial_account
+      LEFT JOIN civicrm_contribution AS contribution
+        ON contribution.id = %2
+      LEFT JOIN civicrm_financial_account AS financial_account
+      	ON entity_financial_account.financial_account_id = financial_account.id
+      WHERE entity_financial_account.account_relationship = %1
+        AND entity_financial_account.entity_id = contribution.financial_type_id 
+      LIMIT 1
+      ";
+
+    $dao = CRM_Core_DAO::executeQuery($query, [
+      1 => [self::ACCOUNT_RELATIONSHIP_ID, 'Integer'],
+      2 => [$this->contributionId, 'Integer']
+    ]);
+
+    while ($dao->fetch()) {
+      return $dao->account_code;
+    }
+
+    return 0;
+  }
+
+}

--- a/CRM/Odoosync/Sync/Contribution/Data/ContributionParam.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/ContributionParam.php
@@ -3,13 +3,6 @@
 class CRM_Odoosync_Sync_Contribution_Data_ContributionParam extends CRM_Odoosync_Sync_Contribution_Data {
 
   /**
-   * Account relationship id
-   *
-   * @var int
-   */
-  const ACCOUNT_RELATIONSHIP_ID = 3;
-
-  /**
    * Gets the contribution's params
    *
    * @return array
@@ -124,7 +117,7 @@ class CRM_Odoosync_Sync_Contribution_Data_ContributionParam extends CRM_Odoosync
 
     $dao = CRM_Core_DAO::executeQuery($query, [
       1 => [$this->contributionId, 'Integer'],
-      2 => [self::ACCOUNT_RELATIONSHIP_ID, 'Integer']
+      2 => [CRM_Odoosync_Sync_Contribution_Data_AccountRelationShip::getAccountsReceivableAccountRelationshipId(), 'Integer']
     ]);
 
     while ($dao->fetch()) {

--- a/CRM/Odoosync/Sync/Contribution/Data/ContributionParam.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/ContributionParam.php
@@ -117,7 +117,7 @@ class CRM_Odoosync_Sync_Contribution_Data_ContributionParam extends CRM_Odoosync
 
     $dao = CRM_Core_DAO::executeQuery($query, [
       1 => [$this->contributionId, 'Integer'],
-      2 => [CRM_Odoosync_Sync_Contribution_Data_AccountRelationShip::getAccountsReceivableAccountRelationshipId(), 'Integer']
+      2 => [CRM_Odoosync_Sync_Contribution_Data_AccountRelationShip::getAccountsReceivableId(), 'Integer']
     ]);
 
     while ($dao->fetch()) {

--- a/CRM/Odoosync/Sync/Contribution/Data/LineItem.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/LineItem.php
@@ -109,8 +109,8 @@ class CRM_Odoosync_Sync_Contribution_Data_LineItem extends CRM_Odoosync_Sync_Con
 
     $dao = CRM_Core_DAO::executeQuery($query, [
       1 => [$this->contributionId, 'Integer'],
-      2 => [CRM_Odoosync_Sync_Contribution_Data_AccountRelationShip::getIncomeAccountRelationshipId(), 'Integer'],
-      3 => [CRM_Odoosync_Sync_Contribution_Data_AccountRelationShip::getSalesTaxAccountRelationshipId(), 'Integer']
+      2 => [CRM_Odoosync_Sync_Contribution_Data_AccountRelationShip::getIncomeAccountId(), 'Integer'],
+      3 => [CRM_Odoosync_Sync_Contribution_Data_AccountRelationShip::getSalesTaxAccountId(), 'Integer']
     ]);
 
     $lineItemList = [];
@@ -142,7 +142,7 @@ class CRM_Odoosync_Sync_Contribution_Data_LineItem extends CRM_Odoosync_Sync_Con
   private function calculateProductCode($entityTable) {
     switch ($entityTable) {
       case "civicrm_participant":
-        $productCode = "THEN";
+        $productCode = "CVEVT";
         break;
 
       case "civicrm_membership":

--- a/CRM/Odoosync/Sync/Contribution/Data/LineItem.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/LineItem.php
@@ -27,11 +27,12 @@ class CRM_Odoosync_Sync_Contribution_Data_LineItem extends CRM_Odoosync_Sync_Con
     $lineItems = [];
     $lineItemsData = $this->generateItemsData();
     foreach ($lineItemsData as $lineItem) {
+      $taxNameList = is_null($lineItem['tax_name']) ? [] : [$lineItem['tax_name']];
       $lineItems[] = [
         [
           'name' => 'tax_name',
           'type' => 'string',
-          'value' => [$lineItem['tax_name']]
+          'value' => $taxNameList
         ],
         [
           'name' => 'account_code',
@@ -61,7 +62,7 @@ class CRM_Odoosync_Sync_Contribution_Data_LineItem extends CRM_Odoosync_Sync_Con
         [
           'name' => 'x_civicrm_id',
           'type' => 'int',
-          'value' => $lineItem['contact_id']
+          'value' => $lineItem['line_item_id']
         ],
         [
           'name' => 'quantity',
@@ -111,6 +112,7 @@ class CRM_Odoosync_Sync_Contribution_Data_LineItem extends CRM_Odoosync_Sync_Con
         contribution.contact_id AS contact_id,
         line_item.unit_price AS unit_price,
         line_item.line_total AS total,
+        line_item.id AS line_item_id,
         (
           SELECT financial_account.accounting_code
           FROM civicrm_entity_financial_account AS entity_financial_account
@@ -160,7 +162,8 @@ class CRM_Odoosync_Sync_Contribution_Data_LineItem extends CRM_Odoosync_Sync_Con
         'total' => $dao->total,
         'account_code' => (!is_null($dao->account_code)) ? $dao->account_code : '',
         'contact_id' => $dao->contact_id,
-        'tax_name' => (!is_null($dao->tax_name)) ? $dao->tax_name : '',
+        'tax_name' => (!is_null($dao->tax_name)) ? $dao->tax_name : NULL,
+        'line_item_id' => $dao->line_item_id,
         'unit_price' => $dao->unit_price
       ];
     }

--- a/CRM/Odoosync/Sync/Contribution/Data/LineItem.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/LineItem.php
@@ -1,0 +1,171 @@
+<?php
+
+class CRM_Odoosync_Sync_Contribution_Data_LineItem extends CRM_Odoosync_Sync_Contribution_Data {
+
+  /**
+   * Account relationship id
+   * (Income Account is)
+   *
+   * @var int
+   */
+  const INCOME_ACCOUNT_RELATIONSHIP_ID = 1;
+
+  /**
+   * Account relationship id
+   * (Sales Tax Account is)
+   *
+   * @var int
+   */
+  const SALES_ACCOUNT_RELATIONSHIP_ID = 10;
+
+  /**
+   * Gets line item params
+   *
+   * @return array
+   */
+  public function retrieve() {
+    $lineItems = [];
+    $lineItemsData = $this->generateItemsData();
+    foreach ($lineItemsData as $lineItem) {
+      $lineItems[] = [
+        [
+          'name' => 'tax_name',
+          'type' => 'string',
+          'value' => [$lineItem['tax_name']]
+        ],
+        [
+          'name' => 'account_code',
+          'type' => 'int',
+          'value' => $lineItem['account_code']
+        ],
+        [
+          'name' => 'name',
+          'type' => 'string',
+          'value' => $lineItem['label']
+        ],
+        [
+          'name' => 'price_subtotal',
+          'type' => 'double',
+          'value' => $lineItem['total']
+        ],
+        [
+          'name' => 'price_unit',
+          'type' => 'double',
+          'value' => $lineItem['unit_price']
+        ],
+        [
+          'name' => 'product_code',
+          'type' => 'string',
+          'value' => $lineItem['product_code']
+        ],
+        [
+          'name' => 'x_civicrm_id',
+          'type' => 'int',
+          'value' => $lineItem['contact_id']
+        ],
+        [
+          'name' => 'quantity',
+          'type' => 'double',
+          'value' => $lineItem['quantity']
+        ]
+      ];
+    }
+
+    return $lineItems;
+  }
+
+  /**
+   * Gets line item data
+   *
+   * @return array
+   */
+  private function generateItemsData() {
+    $query = "
+      SELECT 
+        (
+          CASE  
+            WHEN 
+              line_item.entity_table = 'civicrm_participant'
+            THEN 
+              'CVEVT'
+            WHEN 
+              line_item.entity_table = 'civicrm_membership'
+            THEN 
+              'CVMEM'
+            WHEN 
+              line_item.entity_table = 'civicrm_booking_slot'
+              OR line_item.entity_table = 'civicrm_booking_sub_slot'
+              OR line_item.entity_table = 'civicrm_booking_adhoc_charges'
+            THEN 
+              'CVBK'
+            WHEN 
+              line_item.entity_table = 'civicrm_contribution'
+            THEN 
+              'CVCTB'
+            ELSE
+              '' 
+            END
+        ) AS product_code,
+        line_item.label AS label,
+        line_item.qty AS quantity,
+        contribution.contact_id AS contact_id,
+        line_item.unit_price AS unit_price,
+        line_item.line_total AS total,
+        (
+          SELECT financial_account.accounting_code
+          FROM civicrm_entity_financial_account AS entity_financial_account
+          LEFT JOIN civicrm_financial_account AS financial_account
+            ON entity_financial_account.financial_account_id = financial_account.id
+          WHERE entity_financial_account.account_relationship = %2
+            AND entity_financial_account.entity_id = line_item.financial_type_id 
+          LIMIT 1
+        ) AS account_code,
+        (
+          SELECT financial_account.name
+          FROM civicrm_entity_financial_account AS entity_financial_account
+          LEFT JOIN civicrm_financial_account AS financial_account
+            ON entity_financial_account.financial_account_id = financial_account.id
+          WHERE entity_financial_account.account_relationship = %3
+            AND entity_financial_account.entity_id = line_item.financial_type_id 
+          LIMIT 1
+        ) AS tax_name
+      FROM civicrm_line_item AS line_item
+      LEFT JOIN civicrm_contribution AS contribution
+          ON contribution.id = %1
+      WHERE line_item.contribution_id = %1
+        AND 
+          (
+            line_item.entity_table = 'civicrm_participant' OR
+            line_item.entity_table = 'civicrm_membership' OR
+            line_item.entity_table = 'civicrm_booking_slot' OR
+            line_item.entity_table = 'civicrm_booking_sub_slot' OR
+            line_item.entity_table = 'civicrm_booking_adhoc_charges' OR
+            line_item.entity_table = 'civicrm_contribution'
+          )
+    ";
+
+    $dao = CRM_Core_DAO::executeQuery($query, [
+      1 => [$this->contributionId, 'Integer'],
+      2 => [self::INCOME_ACCOUNT_RELATIONSHIP_ID, 'Integer'],
+      3 => [self::SALES_ACCOUNT_RELATIONSHIP_ID, 'Integer']
+    ]);
+
+    $lineItemList = [];
+
+    while ($dao->fetch()) {
+      $lineItemList[] = [
+        'product_code' => $dao->product_code,
+        'label' => $dao->label,
+        'quantity' => $dao->quantity,
+        'total' => $dao->total,
+        'account_code' => (!is_null($dao->account_code)) ? $dao->account_code : '',
+        'contact_id' => $dao->contact_id,
+        'tax_name' => (!is_null($dao->tax_name)) ? $dao->tax_name : '',
+        'unit_price' => $dao->unit_price
+      ];
+    }
+
+    return $lineItemList;
+  }
+
+}

--- a/CRM/Odoosync/Sync/Contribution/Data/Payment.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/Payment.php
@@ -1,0 +1,126 @@
+<?php
+
+class CRM_Odoosync_Sync_Contribution_Data_Payment extends CRM_Odoosync_Sync_Contribution_Data {
+
+  /**
+   * Returns payment data
+   *
+   * @return mixed
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function retrieve() {
+    $paymentItemsDao = $this->generatePaymentItemsData();
+    $paymentItems = $this->mappedItems($paymentItemsDao);
+
+    return $paymentItems;
+  }
+
+  /**
+   * Gets payment data
+   *
+   * @return \CRM_Core_DAO|object
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function generatePaymentItemsData() {
+    $refundedStatusValueId = CRM_Odoosync_Sync_Contribution_Data_Status::getRefundedValueId();
+    $cancelledStatusValueId = CRM_Odoosync_Sync_Contribution_Data_Status::getCancelledValueId();
+
+    $query = "
+      SELECT 
+        financial_trxn.id AS communication,
+        financial_trxn.trxn_date AS payment_date,
+        financial_trxn.status_id AS status,
+        financial_trxn.currency AS currency_code,
+        financial_trxn.is_payment AS is_payment,
+        financial_trxn.total_amount AS amount,
+        (
+          SELECT financial_account.name AS account_code
+          FROM civicrm_entity_financial_account AS entity_financial_account
+          LEFT JOIN civicrm_financial_account AS financial_account
+            ON entity_financial_account.financial_account_id = financial_account.id
+          WHERE entity_financial_account.account_relationship = %4
+            AND entity_financial_account.entity_id = financial_trxn.to_financial_account_id
+          LIMIT 1
+        ) AS account_code
+      FROM civicrm_entity_financial_trxn AS entity_financial_trxn
+      LEFT JOIN civicrm_financial_trxn AS financial_trxn
+        ON entity_financial_trxn.financial_trxn_id = financial_trxn.id
+      WHERE (financial_trxn.status_id != %2 AND financial_trxn.status_id != %3)
+        AND entity_financial_trxn.entity_table = 'civicrm_contribution'
+        AND entity_financial_trxn.entity_id = %1
+        AND financial_trxn.is_payment = 1
+    ";
+
+    $dao = CRM_Core_DAO::executeQuery($query, [
+      1 => [$this->contributionId, 'Integer'],
+      2 => [$refundedStatusValueId, 'String'],
+      3 => [$cancelledStatusValueId, 'String'],
+      4 => [CRM_Odoosync_Sync_Contribution_Data_LineItem::SALES_ACCOUNT_RELATIONSHIP_ID, 'Integer']
+    ]);
+
+    return $dao;
+  }
+
+  /**
+   * @param \CRM_Core_DAO|object $paymentItemsDao
+   *
+   * @return array
+   */
+  private function mappedItems($paymentItemsDao) {
+    $paymentItems = [];
+    $accountCode = (new CRM_Odoosync_Sync_Contribution_Data_ContributionParam($this->contributionId))->getAccountCode();
+
+    while ($paymentItemsDao->fetch()) {
+      $paymentItems[] = [
+        [
+          'name' => 'status',
+          'type' => 'string',
+          'value' => $paymentItemsDao->status
+        ],
+        [
+          'name' => 'is_payment',
+          'type' => 'int',
+          'value' => $paymentItemsDao->is_payment
+        ],
+        [
+          'name' => 'amount',
+          'type' => 'double',
+          'value' => $paymentItemsDao->amount
+        ],
+        [
+          'name' => 'journal_code',
+          'type' => 'string',
+          'value' => $paymentItemsDao->account_code
+        ],
+        [
+          'name' => 'payment_date',
+          'type' => 'int',
+          'value' => CRM_Odoosync_Common_Date::convertDateToTimestamp($paymentItemsDao->payment_date)
+        ],
+        [
+          'name' => 'communication',
+          'type' => 'string',
+          'value' => $paymentItemsDao->communication
+        ],
+        [
+          'name' => 'account_code',
+          'type' => 'int',
+          'value' => $accountCode
+        ],
+        [
+          'name' => 'x_civicrm_id',
+          'type' => 'int',
+          'value' => $paymentItemsDao->communication
+        ],
+        [
+          'name' => 'currency_code',
+          'type' => 'string',
+          'value' => $paymentItemsDao->currency_code
+        ]
+      ];
+    }
+
+    return $paymentItems;
+  }
+
+}

--- a/CRM/Odoosync/Sync/Contribution/Data/Payment.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/Payment.php
@@ -48,7 +48,7 @@ class CRM_Odoosync_Sync_Contribution_Data_Payment extends CRM_Odoosync_Sync_Cont
       1 => [$this->contributionId, 'Integer'],
       2 => [$refundedStatusValueId, 'String'],
       3 => [$cancelledStatusValueId, 'String'],
-      4 => [CRM_Odoosync_Sync_Contribution_Data_AccountRelationShip::getSalesTaxAccountRelationshipId(), 'Integer']
+      4 => [CRM_Odoosync_Sync_Contribution_Data_AccountRelationShip::getSalesTaxAccountId(), 'Integer']
     ]);
 
     return $dao;

--- a/CRM/Odoosync/Sync/Contribution/Data/Payment.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/Payment.php
@@ -29,16 +29,7 @@ class CRM_Odoosync_Sync_Contribution_Data_Payment extends CRM_Odoosync_Sync_Cont
       SELECT 
         financial_trxn.id AS communication,
         financial_trxn.trxn_date AS payment_date,
-        (
-          CASE  
-            WHEN 
-              financial_trxn.status_id = %2 OR financial_trxn.status_id = %3
-            THEN 
-              ''
-            ELSE
-              financial_trxn.status_id 
-            END
-        ) AS status,
+        financial_trxn.status_id AS status,
         financial_trxn.currency AS currency_code,
         financial_trxn.is_payment AS is_payment,
         financial_trxn.total_amount AS amount,
@@ -57,7 +48,7 @@ class CRM_Odoosync_Sync_Contribution_Data_Payment extends CRM_Odoosync_Sync_Cont
       1 => [$this->contributionId, 'Integer'],
       2 => [$refundedStatusValueId, 'String'],
       3 => [$cancelledStatusValueId, 'String'],
-      4 => [CRM_Odoosync_Sync_Contribution_Data_LineItem::SALES_ACCOUNT_RELATIONSHIP_ID, 'Integer']
+      4 => [CRM_Odoosync_Sync_Contribution_Data_AccountRelationShip::getSalesTaxAccountRelationshipId(), 'Integer']
     ]);
 
     return $dao;
@@ -76,7 +67,7 @@ class CRM_Odoosync_Sync_Contribution_Data_Payment extends CRM_Odoosync_Sync_Cont
         [
           'name' => 'status',
           'type' => 'string',
-          'value' => $paymentItemsDao->status
+          'value' => $this->generateStatus($paymentItemsDao->status)
         ],
         [
           'name' => 'is_payment',
@@ -117,6 +108,24 @@ class CRM_Odoosync_Sync_Contribution_Data_Payment extends CRM_Odoosync_Sync_Cont
     }
 
     return $paymentItems;
+  }
+
+  /**
+   * Calculates status
+   *
+   * @param $statusId
+   *
+   * @return string
+   */
+  private function generateStatus($statusId) {
+    if (
+      $statusId == CRM_Odoosync_Sync_Contribution_Data_Status::getRefundedValueId()
+      || $statusId == CRM_Odoosync_Sync_Contribution_Data_Status::getCancelledValueId()
+    ) {
+      return '';
+    }
+
+    return $statusId;
   }
 
 }

--- a/CRM/Odoosync/Sync/Contribution/Data/Refund.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/Refund.php
@@ -25,16 +25,7 @@ class CRM_Odoosync_Sync_Contribution_Data_Refund extends CRM_Odoosync_Sync_Contr
     $query = "
       SELECT 
         financial_trxn.trxn_date AS payment_date,
-        (
-          CASE  
-            WHEN 
-              financial_trxn.status_id != %2 AND financial_trxn.status_id != %3
-            THEN 
-              ''
-            ELSE
-              financial_trxn.status_id 
-            END
-        ) AS status_id
+        financial_trxn.status_id AS status_id
       FROM civicrm_entity_financial_trxn AS entity_financial_trxn
       LEFT JOIN civicrm_financial_trxn AS financial_trxn
         ON entity_financial_trxn.financial_trxn_id = financial_trxn.id

--- a/CRM/Odoosync/Sync/Contribution/Data/Refund.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/Refund.php
@@ -1,0 +1,70 @@
+<?php
+
+class CRM_Odoosync_Sync_Contribution_Data_Refund extends CRM_Odoosync_Sync_Contribution_Data {
+
+  /**
+   * Returns refund data
+   *
+   * @return mixed
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function retrieve() {
+    $refundItems = $this->generateItemsData();
+
+    return $refundItems;
+  }
+
+  /**
+   * Gets refund data
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function generateItemsData() {
+    $refundedStatusValueId = CRM_Odoosync_Sync_Contribution_Data_Status::getRefundedValueId();
+    $cancelledStatusValueId = CRM_Odoosync_Sync_Contribution_Data_Status::getCancelledValueId();
+
+    $query = "
+    SELECT 
+      financial_trxn.trxn_date AS payment_date,
+      financial_trxn.status_id AS status_id
+    FROM civicrm_entity_financial_trxn AS entity_financial_trxn
+    LEFT JOIN civicrm_financial_trxn AS financial_trxn
+      ON entity_financial_trxn.financial_trxn_id = financial_trxn.id
+    WHERE (financial_trxn.status_id = %2 OR financial_trxn.status_id = %3)
+      AND entity_financial_trxn.entity_table = 'civicrm_contribution'
+      AND entity_financial_trxn.entity_id = %1
+  ";
+
+    $dao = CRM_Core_DAO::executeQuery($query, [
+      1 => [$this->contributionId, 'Integer'],
+      2 => [$refundedStatusValueId, 'String'],
+      3 => [$cancelledStatusValueId, 'String']
+    ]);
+
+    $refundItems = [];
+
+    while ($dao->fetch()) {
+      $refundItems[] = [
+        [
+          'name' => 'date',
+          'type' => 'int',
+          'value' => CRM_Odoosync_Common_Date::convertDateToTimestamp($dao->payment_date)
+        ],
+        [
+          'name' => 'description',
+          'type' => 'string',
+          'value' => $this->contributionId
+        ],
+        [
+          'name' => 'status_id',
+          'type' => 'string',
+          'value' => $dao->status_id
+        ]
+      ];
+    }
+
+    return $refundItems;
+  }
+
+}

--- a/CRM/Odoosync/Sync/Contribution/Data/Status.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/Status.php
@@ -5,16 +5,16 @@ class CRM_Odoosync_Sync_Contribution_Data_Status {
   /**
    * Contribution Refunded status 'value ID'
    *
-   * @return bool|string
+   * @return NULL|string
    */
-  private static $refundedValueId = FALSE;
+  private static $refundedValueId = NULL;
 
   /**
    * Contribution cancelled status 'value ID'
    *
-   * @return bool|string
+   * @return NULL|string
    */
-  private static $cancelledValueId = FALSE;
+  private static $cancelledValueId = NULL;
 
   /**
    * Gets contribution refunded status 'value ID'
@@ -22,7 +22,7 @@ class CRM_Odoosync_Sync_Contribution_Data_Status {
    * @return string
    */
   public static function getRefundedValueId() {
-    if (!self::$refundedValueId) {
+    if (is_null(self::$refundedValueId)) {
       self::$refundedValueId = CRM_Odoosync_Common_OptionValue::getOptionValueID('contribution_status', 'Refunded');
     }
 
@@ -35,7 +35,7 @@ class CRM_Odoosync_Sync_Contribution_Data_Status {
    * @return string
    */
   public static function getCancelledValueId() {
-    if (!self::$cancelledValueId) {
+    if (is_null(self::$cancelledValueId)) {
       self::$cancelledValueId = CRM_Odoosync_Common_OptionValue::getOptionValueID('contribution_status', 'Cancelled');
     }
 

--- a/CRM/Odoosync/Sync/Contribution/Data/Status.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/Status.php
@@ -1,0 +1,45 @@
+<?php
+
+class CRM_Odoosync_Sync_Contribution_Data_Status {
+
+  /**
+   * Contribution Refunded status 'value ID'
+   *
+   * @return bool|string
+   */
+  private static $refundedValueId = FALSE;
+
+  /**
+   * Contribution cancelled status 'value ID'
+   *
+   * @return bool|string
+   */
+  private static $cancelledValueId = FALSE;
+
+  /**
+   * Gets contribution refunded status 'value ID'
+   *
+   * @return string
+   */
+  public static function getRefundedValueId() {
+    if (!self::$refundedValueId) {
+      self::$refundedValueId = CRM_Odoosync_Common_OptionValue::getOptionValueID('contribution_status', 'Refunded');
+    }
+
+    return self::$refundedValueId;
+  }
+
+  /**
+   * Gets contribution cancelled status 'value ID'
+   *
+   * @return string
+   */
+  public static function getCancelledValueId() {
+    if (!self::$cancelledValueId) {
+      self::$cancelledValueId = CRM_Odoosync_Common_OptionValue::getOptionValueID('contribution_status', 'Cancelled');
+    }
+
+    return self::$cancelledValueId;
+  }
+
+}

--- a/CRM/Odoosync/Sync/Contribution/InformationGenerator.php
+++ b/CRM/Odoosync/Sync/Contribution/InformationGenerator.php
@@ -1,0 +1,49 @@
+<?php
+
+class CRM_Odoosync_Sync_Contribution_InformationGenerator {
+
+  /**
+   * Sync contribution id
+   *
+   * @var int
+   */
+  private $contributionId;
+
+  /**
+   * Contribution fields
+   *
+   * @var array
+   */
+  private $fieldsToGenerate = [];
+
+  /**
+   * CRM_Odoosync_Sync_Contribution_InformationGenerator constructor.
+   *
+   * @param int $contributionId
+   */
+  public function __construct($contributionId) {
+    $this->contributionId = $contributionId;
+  }
+
+  /**
+   * Prepares contribution data for sync
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function generate() {
+    $lineItems = (new CRM_Odoosync_Sync_Contribution_Data_LineItem($this->contributionId))->retrieve();
+    $contributionParams = (new CRM_Odoosync_Sync_Contribution_Data_ContributionParam($this->contributionId))->retrieve();
+    $paymentList = (new CRM_Odoosync_Sync_Contribution_Data_Payment($this->contributionId))->retrieve();
+    $refundList = (new CRM_Odoosync_Sync_Contribution_Data_Refund($this->contributionId))->retrieve();
+
+    $this->fieldsToGenerate = [
+      'lineItems' => $lineItems,
+      'contributionParams' => $contributionParams,
+      'paymentList' => $paymentList,
+      'refundList' => $refundList,
+    ];
+
+    return $this->fieldsToGenerate;
+  }
+
+}

--- a/CRM/Odoosync/Sync/Contribution/PendingContribution.php
+++ b/CRM/Odoosync/Sync/Contribution/PendingContribution.php
@@ -1,12 +1,12 @@
 <?php
 
 /**
- * Gets appropriate contacts for synchronization with Odoo
+ * Gets appropriate contribution for synchronization with Odoo
  */
-class CRM_Odoosync_Sync_Contact_PendingContacts {
+class CRM_Odoosync_Sync_Contribution_PendingContribution {
 
   /**
-   * Sync contact id
+   * Sync contribution id
    *
    * @var int
    */
@@ -20,13 +20,13 @@ class CRM_Odoosync_Sync_Contact_PendingContacts {
   private $syncStatusValue;
 
   /**
-   * CRM_Odoosync_Sync_Contact_PendingContacts constructor.
+   * CRM_Odoosync_Sync_Contribution_PendingContribution constructor.
    *
    * @throws \CiviCRM_API3_Exception
    */
   public function __construct() {
     $this->syncStatusFieldId = CRM_Odoosync_Common_CustomField::getCustomFieldId(
-      'odoo_partner_sync_information',
+      'odoo_invoice_sync_information',
       'sync_status'
     );
     $this->syncStatusValue = CRM_Odoosync_Common_OptionValue::getOptionValueID(
@@ -36,27 +36,27 @@ class CRM_Odoosync_Sync_Contact_PendingContacts {
   }
 
   /**
-   * Gets non-synchronized contact Ids
+   * Gets non-synchronized contribution Ids
    *
    * @return array
    */
-  public function getPendingContacts() {
+  public function getPendingContributions() {
     $syncSetting = CRM_Odoosync_Setting::getInstance()->retrieve();
 
     try {
-      $contactList = civicrm_api3('Contact', 'get', [
+      $contributionList = civicrm_api3('Contribution', 'get', [
         'return' => ["id"],
         'is_deleted' => ['IS NOT NULL' => 1],
         'options' => ['limit' => (int) $syncSetting['odoosync_batch_size']],
         'custom_' . $this->syncStatusFieldId => $this->syncStatusValue,
       ]);
 
-      $contactListId = [];
-      foreach ($contactList['values'] as $contact) {
-        $contactListId[] = $contact['contact_id'];
+      $contributionListId = [];
+      foreach ($contributionList['values'] as $contribution) {
+        $contributionListId[] = $contribution['contribution_id'];
       }
 
-      return $contactListId;
+      return $contributionListId;
     }
     catch (CiviCRM_API3_Exception $e) {
       return [];

--- a/CRM/Odoosync/Sync/Contribution/PendingContribution.php
+++ b/CRM/Odoosync/Sync/Contribution/PendingContribution.php
@@ -40,7 +40,7 @@ class CRM_Odoosync_Sync_Contribution_PendingContribution {
    *
    * @return array
    */
-  public function getPendingContributions() {
+  public function getIds() {
     $syncSetting = CRM_Odoosync_Setting::getInstance()->retrieve();
 
     try {

--- a/api/v3/OdooSync.php
+++ b/api/v3/OdooSync.php
@@ -9,22 +9,7 @@
  * @throws \Exception
  */
 function civicrm_api3_odoo_sync_run($params) {
-  $log = [];
-  $logContact = (new CRM_Odoosync_Sync_Contact($params))->run();
-  $logContribution = (new CRM_Odoosync_Sync_Contribution($params))->run();
-
-  $log['is_error'] = ($logContact['is_error'] == 1 || $logContact['is_error'] == 1) ? 1 : 0;
-
-  //more detail log can view in api when debug = 1
-  if ($params['debug'] == 1) {
-    $log['debugLog']['contacts_debug_log'] = $logContact['debugLog'];
-    $log['debugLog']['contribution_debug_log'] = $logContribution['debugLog'];
-  }
-
-  //this log can view on schedule job
-  $log['values'] = '<br/>' . $logContact['values'] . $logContribution['values'];
-
-  return $log;
+  return (new CRM_Odoosync_Sync())->run($params);
 }
 
 /**

--- a/api/v3/OdooSync.php
+++ b/api/v3/OdooSync.php
@@ -9,8 +9,22 @@
  * @throws \Exception
  */
 function civicrm_api3_odoo_sync_run($params) {
-  $sync = new CRM_Odoosync_Sync_Contact($params);
-  return $sync->run();
+  $log = [];
+  $logContact = (new CRM_Odoosync_Sync_Contact($params))->run();
+  $logContribution = (new CRM_Odoosync_Sync_Contribution($params))->run();
+
+  $log['is_error'] = ($logContact['is_error'] == 1 || $logContact['is_error'] == 1) ? 1 : 0;
+
+  //more detail log can view in api when debug = 1
+  if ($params['debug'] == 1) {
+    $log['debugLog']['contacts_debug_log'] = $logContact['debugLog'];
+    $log['debugLog']['contribution_debug_log'] = $logContribution['debugLog'];
+  }
+
+  //this log can view on schedule job
+  $log['values'] = '<br/>' . $logContact['values'] . $logContribution['values'];
+
+  return $log;
 }
 
 /**


### PR DESCRIPTION
1. The "Sync CiviCRM changes to Odoo" job processes the contribution records whose "Sync Status" is "Awaiting Sync" and "Received Date" is smaller or equals to today. One API call is made to Odoo for every Contribution record to sync with following information to Odoo:
- The value from the CiviCRM fields specified for contribution tab of the mapping sheet (includes the contribution, all its line items and financial transactions with is_payment =1)
- Action to Sync
- Action Date

2. The API call should return the following information in its response:
- is_error - 0 when successful and 1 when failed
- error_log - present when is_error is 1 and should catch the error information
- invoice_number - the number of the latest invoice created in Odoo for the corresponding contribution
- creditnote_number - the number of the latest refund invoice created in Odoo for the corresponding contribution
- timestamp - the timestamp when the respond is made.

When is_error = 0:
![cos-20-error-0](https://user-images.githubusercontent.com/36959503/39775552-e87b26d2-5306-11e8-967c-139aebe5f604.gif)

When is_error = 1:
![cos-20-error-1](https://user-images.githubusercontent.com/36959503/39775577-044b46d0-5307-11e8-9769-9877c41728c6.gif)
 
