### PR TITLE
COS-21: Post-sync status update for CiviCRM Contribution

### DIFF
--- a/CRM/Odoosync/Common/Date.php
+++ b/CRM/Odoosync/Common/Date.php
@@ -3,6 +3,13 @@
 class CRM_Odoosync_Common_Date {
 
   /**
+   * MySQL format date
+   *
+   * @var string
+   */
+  const MYSQL_FORMAT_DATE = 'Y-m-d H:i:s';
+
+  /**
    * Converts date into timestamp
    * In default use MySQL date format('Y-m-d H:i:s')
    *
@@ -11,10 +18,25 @@ class CRM_Odoosync_Common_Date {
    *
    * @return int
    */
-  public static function convertDateToTimestamp($mysqlDate, $inputDateFormat = 'Y-m-d H:i:s') {
+  public static function convertDateToTimestamp($mysqlDate, $inputDateFormat = self::MYSQL_FORMAT_DATE) {
     $date = DateTime::createFromFormat($inputDateFormat, $mysqlDate);
 
     return ($date) ? $date->getTimestamp() : 0;
+  }
+
+  /**
+   * Converts timestamp into date
+   * In default use MySQL date format('Y-m-d H:i:s')
+   *
+   * @param $timestamp
+   *
+   * @return int
+   */
+  public static function convertTimestampToDate($timestamp) {
+    $date = new DateTime();
+    $date->setTimestamp($timestamp);
+
+    return $date->format(self::MYSQL_FORMAT_DATE);
   }
 
 }

--- a/CRM/Odoosync/Sync/Contribution/ResponseHandler.php
+++ b/CRM/Odoosync/Sync/Contribution/ResponseHandler.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * Updates contribution sync information when sync successful/error
+ */
+class CRM_Odoosync_Sync_Contribution_ResponseHandler {
+
+  /**
+   * Updates contribution sync information when synchronization was successful
+   *
+   * @param $contributionId
+   * @param $creditNoteNumber
+   * @param $invoiceNumber
+   * @param $timestamp
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function handleSuccess($contributionId, $creditNoteNumber, $invoiceNumber, $timestamp) {
+    $syncStatusId = CRM_Odoosync_Common_OptionValue::getOptionValueID('odoo_sync_status', 'synced');
+    $mysqlDate = $this->getMysqlDate($timestamp);
+
+    $paramQuery = [
+      1 => [$contributionId, 'Integer'],
+      2 => [$syncStatusId , 'String'],
+      3 => [$mysqlDate , 'String']
+    ];
+
+    $query = "UPDATE odoo_invoice_sync_information AS sync_info SET ";
+
+    if (!is_null($creditNoteNumber)) {
+      $query .= "sync_info.odoo_credit_note_number = %5, ";
+      $paramQuery[5] = [$creditNoteNumber , 'String'];
+    }
+    else {
+      $query .= "sync_info.odoo_credit_note_number = NULL, ";
+    }
+
+    if (!is_null($invoiceNumber)) {
+      $query .= "sync_info.odoo_invoice_number = %4, ";
+      $paramQuery[4] = [$invoiceNumber , 'String'];
+    }
+    else {
+      $query .= "sync_info.odoo_invoice_number = NULL, ";
+    }
+
+    $query .= "
+      sync_info.last_successful_sync_date = %3,
+      sync_info.sync_status = %2,
+      sync_info.action_to_sync = NULL,
+      sync_info.action_date = NULL,
+      sync_info.last_retry = NULL,
+      sync_info.retry_count = 0,
+      sync_info.error_log = NULL
+      WHERE entity_id = %1 
+    ";
+
+    CRM_Core_DAO::executeQuery($query, $paramQuery);
+  }
+
+  /**
+   * Updates contribution sync information when synchronization was failed
+   *
+   * @param string $errorMessage
+   * @param int $retryThreshold
+   * @param $contributionId
+   *
+   * @param $timestamp
+   *
+   * @return bool
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function handleError($errorMessage, $retryThreshold, $contributionId, $timestamp) {
+    $retryCount = $this->getRetryCount($contributionId);
+    $newRetryCount = $retryCount + 1;
+    $isReachedRetryThreshold = ($newRetryCount >= $retryThreshold);
+    $mysqlDate = $this->getMysqlDate($timestamp);
+
+    $queryParam = [
+      1 => [$contributionId, 'Integer'],
+      2 => [(int) $newRetryCount , 'Integer'],
+      3 => [$errorMessage , 'String'],
+      4 => [$mysqlDate , 'String'],
+    ];
+
+    if ($isReachedRetryThreshold) {
+      $syncFailedStatusId = CRM_Odoosync_Common_OptionValue::getOptionValueID('odoo_sync_status', 'sync_failed');
+      $query = "
+        UPDATE odoo_invoice_sync_information AS sync_info
+        SET
+          sync_info.last_retry = %4,
+          sync_info.error_log = %3,
+          sync_info.retry_count = %2,
+          sync_info.sync_status = %5
+        WHERE entity_id = %1
+      ";
+      $queryParam[5] = [$syncFailedStatusId , 'String'];
+    }
+    else {
+      $query = "
+        UPDATE odoo_invoice_sync_information AS sync_info
+        SET
+          sync_info.last_retry = %4,
+          sync_info.error_log = %3,
+          sync_info.retry_count = %2
+        WHERE sync_info.entity_id = %1
+      ";
+    }
+
+    CRM_Core_DAO::executeQuery($query, $queryParam);
+
+    return $isReachedRetryThreshold;
+  }
+
+  /**
+   * Gets contribution's retry count
+   *
+   * @param int $contributionId
+   *
+   * @return int
+   */
+  private function getRetryCount($contributionId) {
+    $query = "SELECT retry_count FROM odoo_invoice_sync_information WHERE entity_id = %1 LIMIT 1";
+    $dao = CRM_Core_DAO::executeQuery($query, [1 => [$contributionId, 'Integer']]);
+
+    while ($dao->fetch()) {
+      return (int) $dao->retry_count;
+    }
+
+    return 0;
+  }
+
+  /**
+   * Validates timestamp
+   *
+   * @param $timestamp
+   *
+   * @return string
+   */
+  private function getMysqlDate($timestamp) {
+    if (empty($timestamp)) {
+      return (new DateTime())->format(CRM_Odoosync_Common_Date::MYSQL_FORMAT_DATE);
+    }
+
+    return CRM_Odoosync_Common_Date::convertTimestampToDate($timestamp);
+  }
+
+}


### PR DESCRIPTION
1. If a record is successfully synced (the sync callback gives is_error = 0):
- its "Sync Status" field is marked as "Synced"
- its "Last Successful Sync Date" is filled with the timestamp of the successful sync callback
- its "Odoo Invoice Number" is filled with the invoice_number from the callback
- its "Odoo Credit Note Number" is filled with the creditnote_number from the callback
- its "Action to Sync", "Action Date", "Last Retry", "Retry Count" and "Error Log" fields should be emptied

![cos-21-error-0](https://user-images.githubusercontent.com/36959503/39927095-e266ec4c-5539-11e8-999a-9063d3038f20.gif)

2. If a record is failed to be synced (the sync callback gives is_error = 1):
- its "Last Successful Sync Date", "Sync Status", "Action to Sync", "Action Date" stay unchanged
- its "Retry Count" field is plus one
- its "Last Retry" field is filled with the timestamp of the errored sync callback
- its "Error Log" field is filled with the error_log information from the errored sync callback
- if the "Retry Count" has reached the number defined by "retry-threshold" in the scheduled job, the "Sync Status" is marked as "Sync failed".

![cos-21-error-1](https://user-images.githubusercontent.com/36959503/39927125-f4ad6084-5539-11e8-87d2-00b7b45d7d9d.gif)

