### PR TITLE
COS-34: Inbound Sync Handling for Contribution Payments when api call is made from Odoo side.

### DIFF
--- a/CRM/Odoosync/Hook/Post/LineItem.php
+++ b/CRM/Odoosync/Hook/Post/LineItem.php
@@ -12,6 +12,10 @@ class CRM_Odoosync_Hook_Post_LineItem extends CRM_Odoosync_Hook_Post_Base {
    */
   public function process() {
     $contributionId = $this->objectRef->contribution_id;
+    if (!$contributionId) {
+      return;
+    }
+
     if (!$this->isSyncStatusSynced($contributionId)) {
       return;
     }

--- a/CRM/Odoosync/Sync/Inbound/Transaction.php
+++ b/CRM/Odoosync/Sync/Inbound/Transaction.php
@@ -145,7 +145,7 @@ class CRM_Odoosync_Sync_Inbound_Transaction {
    *
    * @return bool
    */
-  public function isContributionExist($contributionId) {
+  private function isContributionExist($contributionId) {
     try {
       $contribution = civicrm_api3('Contribution', 'getsingle', [
         'return' => "id",
@@ -171,7 +171,7 @@ class CRM_Odoosync_Sync_Inbound_Transaction {
       return;
     }
 
-    $connectTransaction = $this->connectTransactionToContribution(
+    $connectTransaction = $this->createEntityFinancialTrxn(
       $financialTrxnId,
       $params['contribution_id'],
       $params['total_amount']
@@ -209,7 +209,7 @@ class CRM_Odoosync_Sync_Inbound_Transaction {
    *
    * @return bool
    */
-  private function connectTransactionToContribution($financialTrxnId, $contributionId, $amount) {
+  private function createEntityFinancialTrxn($financialTrxnId, $contributionId, $amount) {
     try {
       $entityFinancialTrxn = civicrm_api3('EntityFinancialTrxn', 'create', [
         'entity_table' => "civicrm_contribution",

--- a/CRM/Odoosync/Sync/Inbound/Transaction.php
+++ b/CRM/Odoosync/Sync/Inbound/Transaction.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * Handles syncing transaction data from Odoo
+ */
+class CRM_Odoosync_Sync_Inbound_Transaction {
+
+  /**
+   * List of the CiviCRM response fields to Odoo
+   *
+   * @var array
+   */
+  private $syncResponse = ['is_error' => 0];
+
+  /**
+   * Starts transaction sync from Odoo
+   *
+   */
+  public function run() {
+    $inboundData = trim(file_get_contents('php://input'));
+    $response = CRM_Odoosync_Sync_Request_XmlGenerator::xmlToObject($inboundData);
+    $params = [];
+
+    if (!$response) {
+      $this->syncResponse['is_error'] = 1;
+      $this->syncResponse['error_message'] = ts('Can\'t parse a XML response.');
+    }
+    else {
+      $params = $this->parseResponse($response);
+      $this->validateParams($params);
+    }
+
+    if (!$this->syncResponse['is_error']) {
+      $this->syncTransactions($params);
+    }
+
+    $this->returnResponse();
+  }
+
+  /**
+   * Parses xml object
+   *
+   * @param \SimpleXMLElement $response
+   *
+   * @return array
+   */
+  private function parseResponse($response) {
+    $parsedData = [];
+
+    if (isset($response->params->param->value->struct->financial_trxn)) {
+      foreach ($response->params->param->value->struct->financial_trxn as $param) {
+        if (!empty($param->name) && !empty($param->value)) {
+          $parsedData[(string) $param->name] = (string) $param->value;
+        }
+      }
+    }
+
+    if (empty($parsedData)) {
+      $this->syncResponse['is_error'] = 1;
+      $this->syncResponse['error_message'] = ts('Response is empty.');
+    }
+
+    return $parsedData;
+  }
+
+  /**
+   * Validates transaction params
+   *
+   * @param array $params
+   *
+   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
+   */
+  private function validateParams(&$params) {
+    $requiredParameters = [
+      'to_financial_account_id' => 'String',
+      'total_amount' => 'String',
+      'trxn_date' => 'String',
+      'currency' => 'String',
+    ];
+
+    foreach ($requiredParameters as $param => $type) {
+      $params[$param] = CRM_Utils_Type::validate(CRM_Utils_Array::value($param, $params), $type);
+    }
+    $params['to_financial_account_id'] = civicrm_api3('FinancialAccount', 'getvalue', [
+      'return' => "id",
+      'name' => $params['to_financial_account_id'],
+    ]);
+
+    if (empty($params['to_financial_account_id'])) {
+      $this->syncResponse['is_error'] = 1;
+      $this->syncResponse['error_message'] = ts('Can not find a Financial Account');
+    }
+  }
+
+  /**
+   * Creates transaction
+   *
+   * @param array $params
+   */
+  protected function syncTransactions($params) {
+    $transaction = CRM_Core_BAO_FinancialTrxn::create($params);
+
+    if (!$transaction) {
+      $this->syncResponse['is_error'] = 1;
+      $this->syncResponse['error_message'] = ts('Can not create a transaction');
+    }
+    else {
+      $this->syncResponse['transaction_id'] = $transaction->id;
+      $this->syncResponse['timestamp'] = time();
+    }
+  }
+
+  /**
+   * Outputs XML response
+   */
+  protected function returnResponse() {
+    $xml = new SimpleXMLElement('<ResultSet/>');
+    $result = $xml->addChild('Result');
+
+    foreach ($this->syncResponse as $name => $value) {
+      $result->addChild($name, $value);
+    }
+    echo $xml->asXML();
+    CRM_Utils_System::civiExit();
+  }
+
+}

--- a/api/v3/OdooSync.php
+++ b/api/v3/OdooSync.php
@@ -58,7 +58,6 @@ function _civicrm_api3_odoo_sync_send_error_message_spec(&$params) {
  * @throws \Exception
  */
 function civicrm_api3_odoo_sync_transaction($params) {
-  $sync = new CRM_Odoosync_Sync_Inbound_Transaction();
-
-  $sync->run();
+  $transactionSync = new CRM_Odoosync_Sync_Inbound_Transaction();
+  $transactionSync->run();
 }

--- a/api/v3/OdooSync.php
+++ b/api/v3/OdooSync.php
@@ -49,3 +49,16 @@ function _civicrm_api3_odoo_sync_send_error_message_spec(&$params) {
   $params['entity_type']['api.required'] = 1;
   $params['entity_id']['api.required'] = 1;
 }
+
+/**
+ * This API is used for sync transaction from Odoo
+ *
+ * @param $params
+ *
+ * @throws \Exception
+ */
+function civicrm_api3_odoo_sync_transaction($params) {
+  $sync = new CRM_Odoosync_Sync_Inbound_Transaction();
+
+  $sync->run();
+}


### PR DESCRIPTION
1. When an payment sync api call is received, the extension call an CiviCRM function and pass through the information the api call provided according to "Financial Transaction - Payment" in contribution tab of the mapping sheet to create the financial transaction record.
2. The following information should be included in the response to the api call:
- is_error - 0 when successful and 1 when failed
- error_log - present when is_error is 1 and catch the error information
- transction_id - the id of the civicrm transaction that has got created
- timestamp - the timestamp when the respond is made.

When is_error = 0 (payment appears in civicrm_entity_financial_trxn and civicrm_financial_trxn table) 
![cos-34](https://user-images.githubusercontent.com/36959503/40063459-0968f31a-5866-11e8-9cfb-dd87e2e356b5.gif)


When is_error = 1
![cos-34-is error 1](https://user-images.githubusercontent.com/36959503/40063658-7dcdf552-5866-11e8-9c72-ec0b42e755dc.gif)



