### PR TITLE
COS-14: Changes in "Sync CiviCRM changes to Odoo" run order.

### DIFF
--- a/CRM/Odoosync/Sync/BatchSize.php
+++ b/CRM/Odoosync/Sync/BatchSize.php
@@ -3,18 +3,18 @@
 class CRM_Odoosync_Sync_BatchSize {
 
   /**
-   * Current butch size
+   * Current batch size
    *
    * @var int|NULL
    */
   private static $currentBatchSize = NULL;
 
   /**
-   * Gets current butch size
+   * Gets current batch size
    *
    * @return null
    */
-  public static function getCurrentButchSize() {
+  public static function getCurrentBatchSize() {
     if (is_null(self::$currentBatchSize)) {
       self::setBatchSize();
     }
@@ -24,7 +24,7 @@ class CRM_Odoosync_Sync_BatchSize {
 
 
   /**
-   * Decreases number of available lines in current butch
+   * Decreases number of available lines in current batch
    *
    * @param int $usedSize
    */

--- a/CRM/Odoosync/Sync/BatchSize.php
+++ b/CRM/Odoosync/Sync/BatchSize.php
@@ -1,0 +1,47 @@
+<?php
+
+class CRM_Odoosync_Sync_BatchSize {
+
+  /**
+   * Current butch size
+   *
+   * @var int|NULL
+   */
+  private static $currentBatchSize = NULL;
+
+  /**
+   * Gets current butch size
+   *
+   * @return null
+   */
+  public static function getCurrentButchSize() {
+    if (is_null(self::$currentBatchSize)) {
+      self::setBatchSize();
+    }
+
+    return self::$currentBatchSize;
+  }
+
+
+  /**
+   * Decreases number of available lines in current butch
+   *
+   * @param int $usedSize
+   */
+  public static function setUsedSize($usedSize) {
+    if (is_null(self::$currentBatchSize)) {
+      return;
+    }
+
+    self::$currentBatchSize -= (int) $usedSize;
+  }
+
+  /**
+   * Sets batch size from settings
+   */
+  private static function setBatchSize() {
+    $syncSetting = CRM_Odoosync_Setting::getInstance()->retrieve();
+    self::$currentBatchSize = (int) $syncSetting['odoosync_batch_size'];
+  }
+
+}

--- a/CRM/Odoosync/Sync/Contact/PendingContacts.php
+++ b/CRM/Odoosync/Sync/Contact/PendingContacts.php
@@ -41,13 +41,15 @@ class CRM_Odoosync_Sync_Contact_PendingContacts {
    * @return array
    */
   public function getPendingContacts() {
-    $syncSetting = CRM_Odoosync_Setting::getInstance()->retrieve();
-
     try {
       $contactList = civicrm_api3('Contact', 'get', [
         'return' => ["id"],
         'is_deleted' => ['IS NOT NULL' => 1],
-        'options' => ['limit' => (int) $syncSetting['odoosync_batch_size']],
+        'contact_type' => ["Individual", "Organization"],
+        'options' => [
+          'sort' => "contact_type DESC",
+          'limit' => CRM_Odoosync_Sync_BatchSize::getCurrentButchSize()
+        ],
         'custom_' . $this->syncStatusFieldId => $this->syncStatusValue,
       ]);
 
@@ -55,6 +57,8 @@ class CRM_Odoosync_Sync_Contact_PendingContacts {
       foreach ($contactList['values'] as $contact) {
         $contactListId[] = $contact['contact_id'];
       }
+
+      CRM_Odoosync_Sync_BatchSize::setUsedSize(count($contactListId));
 
       return $contactListId;
     }

--- a/CRM/Odoosync/Sync/Contact/PendingContacts.php
+++ b/CRM/Odoosync/Sync/Contact/PendingContacts.php
@@ -48,7 +48,7 @@ class CRM_Odoosync_Sync_Contact_PendingContacts {
         'contact_type' => ["Individual", "Organization"],
         'options' => [
           'sort' => "contact_type DESC",
-          'limit' => CRM_Odoosync_Sync_BatchSize::getCurrentButchSize()
+          'limit' => CRM_Odoosync_Sync_BatchSize::getCurrentBatchSize()
         ],
         'custom_' . $this->syncStatusFieldId => $this->syncStatusValue,
       ]);

--- a/CRM/Odoosync/Sync/Contribution.php
+++ b/CRM/Odoosync/Sync/Contribution.php
@@ -18,7 +18,7 @@ class CRM_Odoosync_Sync_Contribution extends CRM_Odoosync_Sync_BaseHandler {
    * @throws \CiviCRM_API3_Exception
    */
   protected function startSync() {
-    if (CRM_Odoosync_Sync_BatchSize::getCurrentButchSize() <= 0) {
+    if (CRM_Odoosync_Sync_BatchSize::getCurrentBatchSize() <= 0) {
       return $this->getDebuggingData();
     }
 

--- a/CRM/Odoosync/Sync/Contribution.php
+++ b/CRM/Odoosync/Sync/Contribution.php
@@ -18,6 +18,10 @@ class CRM_Odoosync_Sync_Contribution extends CRM_Odoosync_Sync_BaseHandler {
    * @throws \CiviCRM_API3_Exception
    */
   protected function startSync() {
+    if (CRM_Odoosync_Sync_BatchSize::getCurrentButchSize() <= 0) {
+      return $this->getDebuggingData();
+    }
+
     $this->setLog(ts('Start Contribution Syncing ...'));
     $this->setJobLog(ts('Start Contribution Syncing ...'));
 

--- a/CRM/Odoosync/Sync/Contribution/PendingContribution.php
+++ b/CRM/Odoosync/Sync/Contribution/PendingContribution.php
@@ -45,7 +45,7 @@ class CRM_Odoosync_Sync_Contribution_PendingContribution {
       $contributionList = civicrm_api3('Contribution', 'get', [
         'return' => ["id"],
         'is_deleted' => ['IS NOT NULL' => 1],
-        'options' => ['limit' => (int) CRM_Odoosync_Sync_BatchSize::getCurrentButchSize()],
+        'options' => ['limit' => (int) CRM_Odoosync_Sync_BatchSize::getCurrentBatchSize()],
         'custom_' . $this->syncStatusFieldId => $this->syncStatusValue,
       ]);
 

--- a/CRM/Odoosync/Sync/Contribution/PendingContribution.php
+++ b/CRM/Odoosync/Sync/Contribution/PendingContribution.php
@@ -41,13 +41,11 @@ class CRM_Odoosync_Sync_Contribution_PendingContribution {
    * @return array
    */
   public function getIds() {
-    $syncSetting = CRM_Odoosync_Setting::getInstance()->retrieve();
-
     try {
       $contributionList = civicrm_api3('Contribution', 'get', [
         'return' => ["id"],
         'is_deleted' => ['IS NOT NULL' => 1],
-        'options' => ['limit' => (int) $syncSetting['odoosync_batch_size']],
+        'options' => ['limit' => (int) CRM_Odoosync_Sync_BatchSize::getCurrentButchSize()],
         'custom_' . $this->syncStatusFieldId => $this->syncStatusValue,
       ]);
 
@@ -55,6 +53,8 @@ class CRM_Odoosync_Sync_Contribution_PendingContribution {
       foreach ($contributionList['values'] as $contribution) {
         $contributionListId[] = $contribution['contribution_id'];
       }
+
+      CRM_Odoosync_Sync_BatchSize::setUsedSize(count($contributionListId));
 
       return $contributionListId;
     }


### PR DESCRIPTION
The "Sync CiviCRM changes to Odoo" job has the next run order through the CiviCRM records: 
1. ‘Organization’
2. ‘Individual’ 
3. ‘Contribution’.

![cos-14-fix-order sync](https://user-images.githubusercontent.com/36959503/40123246-749fc690-592e-11e8-9422-47f8fdebe22f.gif)
