### PR TITLE
COS-35: "Do not sync" option on Contribution in CiviCRM.

### DIFF
--- a/CRM/Odoosync/Sync/Contribution/PendingContribution.php
+++ b/CRM/Odoosync/Sync/Contribution/PendingContribution.php
@@ -52,27 +52,26 @@ class CRM_Odoosync_Sync_Contribution_PendingContribution {
    * @return array
    */
   public function getIds() {
-    try {
-      $contributionList = civicrm_api3('Contribution', 'get', [
-        'return' => ["id"],
-        'is_deleted' => ['IS NOT NULL' => 1],
-        'options' => ['limit' => (int) CRM_Odoosync_Sync_BatchSize::getCurrentBatchSize()],
-        'custom_' . $this->syncStatusFieldId => $this->syncStatusValue,
-        'custom_' . $this->doNotSyncFieldId =>  ['!=' => 1]
-      ]);
+    $query = "
+      SELECT 
+        contribution.id AS id 
+      FROM civicrm_contribution AS contribution
+      LEFT JOIN odoo_invoice_sync_information AS info 
+        ON contribution.id = info.entity_id
+      WHERE (info.do_not_sync IS NULL OR info.do_not_sync != 1)
+      LIMIT %1
+    ";
 
-      $contributionListId = [];
-      foreach ($contributionList['values'] as $contribution) {
-        $contributionListId[] = $contribution['contribution_id'];
-      }
+    $dao = CRM_Core_DAO::executeQuery($query, [
+      1 => [(int) CRM_Odoosync_Sync_BatchSize::getCurrentBatchSize(), 'Integer']
+    ]);
 
-      CRM_Odoosync_Sync_BatchSize::setUsedSize(count($contributionListId));
-
-      return $contributionListId;
+    $contributionListId = [];
+    while ($dao->fetch()) {
+      $contributionListId[] = $dao->id;
     }
-    catch (CiviCRM_API3_Exception $e) {
-      return [];
-    }
+
+    return $contributionListId;
   }
 
 }

--- a/CRM/Odoosync/Sync/Contribution/PendingContribution.php
+++ b/CRM/Odoosync/Sync/Contribution/PendingContribution.php
@@ -6,7 +6,7 @@
 class CRM_Odoosync_Sync_Contribution_PendingContribution {
 
   /**
-   * Sync contribution id
+   * Custom field id for 'sync_status'
    *
    * @var int
    */
@@ -18,6 +18,13 @@ class CRM_Odoosync_Sync_Contribution_PendingContribution {
    * @var int
    */
   private $syncStatusValue;
+
+  /**
+   * Custom field id for 'do_not_sync'
+   *
+   * @var int
+   */
+  private $doNotSyncFieldId;
 
   /**
    * CRM_Odoosync_Sync_Contribution_PendingContribution constructor.
@@ -33,6 +40,10 @@ class CRM_Odoosync_Sync_Contribution_PendingContribution {
       'odoo_sync_status',
       'awaiting_sync'
     );
+    $this->doNotSyncFieldId = CRM_Odoosync_Common_CustomField::getCustomFieldId(
+      'odoo_invoice_sync_information',
+      'do_not_sync'
+    );
   }
 
   /**
@@ -47,6 +58,7 @@ class CRM_Odoosync_Sync_Contribution_PendingContribution {
         'is_deleted' => ['IS NOT NULL' => 1],
         'options' => ['limit' => (int) CRM_Odoosync_Sync_BatchSize::getCurrentBatchSize()],
         'custom_' . $this->syncStatusFieldId => $this->syncStatusValue,
+        'custom_' . $this->doNotSyncFieldId =>  ['!=' => 1]
       ]);
 
       $contributionListId = [];

--- a/CRM/Odoosync/Sync/Inbound/Transaction.php
+++ b/CRM/Odoosync/Sync/Inbound/Transaction.php
@@ -173,7 +173,7 @@ class CRM_Odoosync_Sync_Inbound_Transaction {
       return;
     }
 
-    $connectToContributionId = $this->createEntityFinancialTrxn(
+    $this->createEntityFinancialTrxn(
       $financialTrxnId,
       $this->validatedParams['contribution_id'],
       $this->validatedParams['total_amount'],

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -336,7 +336,7 @@
             <is_searchable>1</is_searchable>
             <default_value>0</default_value>
             <is_view>0</is_view>
-            <is_required>0</is_required>
+            <is_required>1</is_required>
             <is_active>1</is_active>
             <weight>10</weight>
         </CustomField>

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -326,6 +326,20 @@
             <is_active>1</is_active>
             <weight>9</weight>
         </CustomField>
+        <CustomField>
+            <name>do_not_sync</name>
+            <column_name>do_not_sync</column_name>
+            <label>Do not sync</label>
+            <custom_group_name>odoo_invoice_sync_information</custom_group_name>
+            <data_type>Boolean</data_type>
+            <html_type>Radio</html_type>
+            <is_searchable>1</is_searchable>
+            <default_value>0</default_value>
+            <is_view>0</is_view>
+            <is_required>1</is_required>
+            <is_active>1</is_active>
+            <weight>10</weight>
+        </CustomField>
     </CustomFields>
     <CustomGroups>
         <CustomGroup>

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -336,7 +336,7 @@
             <is_searchable>1</is_searchable>
             <default_value>0</default_value>
             <is_view>0</is_view>
-            <is_required>1</is_required>
+            <is_required>0</is_required>
             <is_active>1</is_active>
             <weight>10</weight>
         </CustomField>


### PR DESCRIPTION
1. - A "Do not sync" boolean custom field provided on the contribution entity.
2. - When "Do not sync" is set to true for a contribution record, the sync scheduled job ignore this contribution record and any other sub-entities(line item, financial transaction etc.) of the contribution.

![cos-35](https://user-images.githubusercontent.com/36959503/40350045-321cc156-5db1-11e8-856b-bc501060ed14.gif)
