### PR TITLE
COS-14: Sending "CiviCRM Odoo Sync Error Report" message template as one email for multiple errors.

### DIFF
--- a/CRM/Odoosync/Sync.php
+++ b/CRM/Odoosync/Sync.php
@@ -17,6 +17,7 @@ class CRM_Odoosync_Sync {
     $log = [];
     $logContact = (new CRM_Odoosync_Sync_Contact($params))->run();
     $logContribution = (new CRM_Odoosync_Sync_Contribution($params))->run();
+    $mailLog = (new CRM_Odoosync_Mail_Error())->sendToRecipients();
 
     $log['is_error'] = ($logContact['is_error'] == 1 || $logContact['is_error'] == 1) ? 1 : 0;
 
@@ -24,10 +25,12 @@ class CRM_Odoosync_Sync {
     if ($params['debug'] == 1) {
       $log['debugLog']['contacts_debug_log'] = $logContact['debugLog'];
       $log['debugLog']['contribution_debug_log'] = $logContribution['debugLog'];
+      $log['debugLog']['mail_debug_log'] = $mailLog;
     }
 
     //this log can view on schedule job
     $log['values'] = '<br/>' . $logContact['values'] . $logContribution['values'];
+    $log['values'] .= !empty($mailLog) ? '<br/>' . $mailLog : '';
 
     return $log;
   }

--- a/CRM/Odoosync/Sync/Contact.php
+++ b/CRM/Odoosync/Sync/Contact.php
@@ -115,9 +115,8 @@ class CRM_Odoosync_Sync_Contact extends CRM_Odoosync_Sync_BaseHandler {
     $this->setLog($errorMessage);
 
     if ($isReachedRetryThreshold) {
-      $this->setLog(ts("Reached retry threshold counter. 'Sync Status' marked as 'Sync failed. Sending errors to emails.'"));
-      $errorMail = new CRM_Odoosync_Mail_Error($this->syncContactId, 'Contact', $errorMessage);
-      $errorMail->sendToRecipients();
+      $this->setLog(ts("Reached retry threshold counter. 'Sync Status' marked as 'Sync failed. Prepare sending errors to emails.'"));
+      CRM_Odoosync_Mail_Error::collectMessage('Contact', $this->syncContactId, $errorMessage);
     }
   }
 

--- a/CRM/Odoosync/Sync/Contribution.php
+++ b/CRM/Odoosync/Sync/Contribution.php
@@ -119,9 +119,8 @@ class CRM_Odoosync_Sync_Contribution extends CRM_Odoosync_Sync_BaseHandler {
     $this->setLog($errorMessage);
 
     if ($isReachedRetryThreshold) {
-      $this->setLog(ts("Reached retry threshold counter. 'Sync Status' marked as 'Sync failed. Sending errors to emails.'"));
-      $errorMail = new CRM_Odoosync_Mail_Error($this->syncContributionId, 'Contribution', $errorMessage);
-      $errorMail->sendToRecipients();
+      $this->setLog(ts("Reached retry threshold counter. 'Sync Status' marked as 'Sync failed. Prepare sending errors to emails.'"));
+      CRM_Odoosync_Mail_Error::collectMessage('Contribution', $this->syncContributionId, $errorMessage);
     }
   }
 

--- a/api/v3/OdooSync.php
+++ b/api/v3/OdooSync.php
@@ -31,8 +31,8 @@ function _civicrm_api3_odoo_sync_run_spec(&$params) {
  * @return mixed
  */
 function civicrm_api3_odoo_sync_send_error_message($params) {
-  $errorMail = new CRM_Odoosync_Mail_Error($params['entity_id'], $params['entity_type'], $params['error_message']);
-  $log = $errorMail->sendToRecipients();
+  CRM_Odoosync_Mail_Error::collectMessage($params['entity_type'], $params['entity_id'], $params['error_message']);
+  $log = (new CRM_Odoosync_Mail_Error())->sendToRecipients();
 
   return $log;
 }

--- a/templates/CRM/Odoosync/DefaultMessageTemplates/OdooSyncErrorReport.html
+++ b/templates/CRM/Odoosync/DefaultMessageTemplates/OdooSyncErrorReport.html
@@ -6,17 +6,17 @@
         <br/>
         <table>
             <tr>
-                <td><p>{ts}Entity type:{/ts}</p></td>
-                <td><p>{$entityType}</p></td>
+                <th>{ts}Entity type{/ts}</th>
+                <th>{ts}Entity id{/ts}</th>
+                <th>{ts}Error log{/ts}</th>
             </tr>
-            <tr>
-                <td><p>{ts}Entity id:{/ts}</p></td>
-                <td><p>{$entityId}</p></td>
-            </tr>
-            <tr>
-                <td><p>{ts}Error log:{/ts}</p></td>
-                <td><p>{$errorMessage}</p></td>
-            </tr>
+            {foreach from=$syncErrorMessageList item='message'}
+                <tr>
+                    <td><p>{$message.entityType}</p></td>
+                    <td><p>{$message.entityId}</p></td>
+                    <td><p>{$message.errorLog}</p></td>
+                </tr>
+            {/foreach}
         </table>
     </body>
 </html>


### PR DESCRIPTION
The only one "CiviCRM Odoo Sync Error Report" email is sent to the email addresses defined in "Error Notice Address" setting when synced records had reached the "Retry Threshold". The email contains the following information for each record that has "Sync Status" field marked as "Sync failed": entity type: contact/ contribution; entity id; error log.

![cos-14-messagetamplate](https://user-images.githubusercontent.com/36959503/40362633-c536c274-5dd5-11e8-8b31-ca63dc750e64.gif)
