### PR TITLE
COS-4 Syncing Contribution 'Purchase order number' from CiviCRM to Odoo

### DIFF
--- a/CRM/Odoosync/Sync/Contribution/Data/ContributionParam.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/ContributionParam.php
@@ -18,7 +18,7 @@ class CRM_Odoosync_Sync_Contribution_Data_ContributionParam extends CRM_Odoosync
       $actionToSyncValueId
     );
     $contactId = $contributionData->contact_id;
-    $name = is_null($contributionData->purchase_order_number) ? $this->contributionId : $contributionData->purchase_order_number;
+    $name = empty($contributionData->purchase_order_number) ? "CIVI " . $this->contributionId : $contributionData->purchase_order_number;
     $accountCode = $contributionData->account_code;
     $currencyCode = $contributionData->currency;
 


### PR DESCRIPTION
1. If Purchase order number for Contribution is not empty in CiviCRM then the same value as Purchase Order Number from CiviCRM to Odoo is synced

![cos-4-purchase number](https://user-images.githubusercontent.com/36959503/40736264-3b870ec2-6446-11e8-9842-2e3ecbe0e8c0.gif)

2. If there is no Purchase order number for Contribution in CiviCRM then in Odoo account_invoice.name = CIVI {contribution id} is created.

![cos-4-no-purchase number](https://user-images.githubusercontent.com/36959503/40736276-40e9b5fe-6446-11e8-9d74-13ac4999a296.gif)
