### PR TITLE
COS-15: Mapping name change for 'receive_date' to 'date_invoice'

### DIFF
--- a/CRM/Odoosync/Sync/Contribution/Data/ContributionParam.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/ContributionParam.php
@@ -49,7 +49,7 @@ class CRM_Odoosync_Sync_Contribution_Data_ContributionParam extends CRM_Odoosync
         'value' => $contactId
       ],
       [
-        'name' => 'receive_date',
+        'name' => 'date_invoice',
         'type' => 'int',
         'value' => $receiveDateTimestamp
       ],


### PR DESCRIPTION
When API call from CiviCRM to Odoo 'civicrm_contribution.receive_date' from mapping has name 'date_invoice'.