### PR TITLE
COS-20: Add timezone offset to timestamp in API call when Sync from CiviCRm to Odoo.

### DIFF
--- a/CRM/Odoosync/Sync/Contribution/Data/ContributionParam.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/ContributionParam.php
@@ -11,13 +11,10 @@ class CRM_Odoosync_Sync_Contribution_Data_ContributionParam extends CRM_Odoosync
   public function retrieve() {
     $contributionData = $this->getContributionData();
     $actionToSyncValueId = $contributionData->action_to_sync;
-    $actionDateTimestamp = $this->getActionDateTimestamp($contributionData->action_date);
-    $receiveDateTimestamp = $this->getActionDateTimestamp($contributionData->receive_date);
+    $receiveDateTimestamp = CRM_Odoosync_Common_Date::convertDateToTimestamp($contributionData->receive_date);
     $receiveDateTimestampWithTimezone = $receiveDateTimestamp + (new DateTime())->getOffset();
-    $actionToSyncName = CRM_Odoosync_Common_OptionValue::getOptionName(
-      'odoo_invoice_action_to_sync',
-      $actionToSyncValueId
-    );
+    $actionDateTimestamp = CRM_Odoosync_Common_Date::convertDateToTimestamp($contributionData->action_date);
+    $actionToSyncName = CRM_Odoosync_Common_OptionValue::getOptionName('odoo_invoice_action_to_sync', $actionToSyncValueId);
     $contactId = $contributionData->contact_id;
     $name = empty($contributionData->purchase_order_number) ? "CIVI " . $this->contributionId : $contributionData->purchase_order_number;
     $accountCode = $contributionData->account_code;
@@ -67,21 +64,6 @@ class CRM_Odoosync_Sync_Contribution_Data_ContributionParam extends CRM_Odoosync
     ];
 
     return $contributionParams;
-  }
-
-  /**
-   * Gets timestamp 'action date'
-   *
-   * @param $actionDate
-   *
-   * @return int
-   */
-  private function getActionDateTimestamp($actionDate) {
-    if (!empty($actionDate)) {
-      return CRM_Odoosync_Common_Date::convertDateToTimestamp($actionDate);
-    }
-
-    return 0;
   }
 
   /**

--- a/CRM/Odoosync/Sync/Contribution/Data/ContributionParam.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/ContributionParam.php
@@ -13,6 +13,7 @@ class CRM_Odoosync_Sync_Contribution_Data_ContributionParam extends CRM_Odoosync
     $actionToSyncValueId = $contributionData->action_to_sync;
     $actionDateTimestamp = $this->getActionDateTimestamp($contributionData->action_date);
     $receiveDateTimestamp = $this->getActionDateTimestamp($contributionData->receive_date);
+    $receiveDateTimestampWithTimezone = $receiveDateTimestamp + (new DateTime())->getOffset();
     $actionToSyncName = CRM_Odoosync_Common_OptionValue::getOptionName(
       'odoo_invoice_action_to_sync',
       $actionToSyncValueId
@@ -51,7 +52,7 @@ class CRM_Odoosync_Sync_Contribution_Data_ContributionParam extends CRM_Odoosync
       [
         'name' => 'date_invoice',
         'type' => 'int',
-        'value' => $receiveDateTimestamp
+        'value' => $receiveDateTimestampWithTimezone
       ],
       [
         'name' => 'action_to_sync',

--- a/CRM/Odoosync/Sync/Contribution/Data/Payment.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/Payment.php
@@ -63,6 +63,8 @@ class CRM_Odoosync_Sync_Contribution_Data_Payment extends CRM_Odoosync_Sync_Cont
     $paymentItems = [];
 
     while ($paymentItemsDao->fetch()) {
+      $paymentDate = CRM_Odoosync_Common_Date::convertDateToTimestamp($paymentItemsDao->payment_date);
+      $paymentDateWithTimezone = $paymentDate + (new DateTime())->getOffset();
       $paymentItems[] = [
         [
           'name' => 'status',
@@ -87,7 +89,7 @@ class CRM_Odoosync_Sync_Contribution_Data_Payment extends CRM_Odoosync_Sync_Cont
         [
           'name' => 'payment_date',
           'type' => 'int',
-          'value' => CRM_Odoosync_Common_Date::convertDateToTimestamp($paymentItemsDao->payment_date)
+          'value' => $paymentDateWithTimezone
         ],
         [
           'name' => 'communication',

--- a/CRM/Odoosync/Sync/Contribution/Data/Refund.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/Refund.php
@@ -43,11 +43,13 @@ class CRM_Odoosync_Sync_Contribution_Data_Refund extends CRM_Odoosync_Sync_Contr
     $refundItems = [];
 
     while ($dao->fetch()) {
+      $date = CRM_Odoosync_Common_Date::convertDateToTimestamp($dao->payment_date);
+      $dateWithTimezone = $date + (new DateTime())->getOffset();
       $refundItems[] = [
         [
           'name' => 'date',
           'type' => 'int',
-          'value' => CRM_Odoosync_Common_Date::convertDateToTimestamp($dao->payment_date)
+          'value' => $dateWithTimezone
         ],
         [
           'name' => 'description',


### PR DESCRIPTION
Add timezone offset to timestamp in API call when Sync from CiviCRm to Odoo for the next fields:
1. 'date_invoice' in 'contribution param' block
2. 'payment_date' in 'payment' block
3. 'date' in 'refund' block