### PR TITLE
COS-44: Update Password Field HTML Type From 'text' To 'password'

### DIFF
--- a/settings/Odoosync.setting.php
+++ b/settings/Odoosync.setting.php
@@ -53,7 +53,7 @@ return [
     'group' => 'odoosync',
     'name' => 'odoosync_password',
     'title' => 'Password',
-    'html_type' => 'text',
+    'html_type' => 'password',
     'quick_form_type' => 'Element',
     'default' => '',
     'is_required' => TRUE,


### PR DESCRIPTION
Overview
----------

When configuring odoo civicrm sync in civicrm, you have to add a password for your odoo login. However the password field is a free text field, this needs to be updated to become a password field, so you can't see the text - everything replaced with asterisk.