### PR TITLE
COS-45: Fixing extension Installation and character escaping issues

### DIFF
--- a/CRM/Odoosync/Sync/Request/XmlGenerator.php
+++ b/CRM/Odoosync/Sync/Request/XmlGenerator.php
@@ -135,11 +135,11 @@ class CRM_Odoosync_Sync_Request_XmlGenerator {
       foreach ($value as $singleValue) {
         $dataElement = $arrayElement->addChild('data');
         $valueElement = $dataElement->addChild('value');
-        $valueElement->addChild($type, $singleValue);
+        $valueElement->addChild($type, htmlspecialchars($singleValue));
       }
     }
     else {
-      $mainValueElement->addChild($type, $value);
+      $mainValueElement->addChild($type, htmlspecialchars($value));
     }
   }
 


### PR DESCRIPTION
## Problem 1
When installing the extension a fatal error will appear which says : 

```
[code] => -1
    [message] => DB Error: unknown error
    [mode] => 16
    [debug_info] => 
      INSERT INTO odoo_partner_sync_information(entity_id, action_to_sync, sync_status)
      SELECT id, 1 , 1 FROM civicrm_contact
      WHERE id NOT IN (SELECT entity_id FROM odoo_partner_sync_information);
       [nativecode=1442 ** Can't update table 'civicrm_contact' in stored function/trigger because it is already used by statement which invoked this stored function/trigger.]
    [type] => DB_Error
    [user_info] => 
      INSERT INTO odoo_partner_sync_information(entity_id, action_to_sync, sync_status)
      SELECT id, 1 , 1 FROM civicrm_contact
      WHERE id NOT IN (SELECT entity_id FROM odoo_partner_sync_information);
       [nativecode=1442 ** Can't update table 'civicrm_contact' in stored function/trigger because it is already used by statement which invoked this stored function/trigger.]
    [to_string] => [db_error: message="DB Error: unknown error" code=-1 mode=callback callback=CRM_Core_Error::exceptionHandler prefix="" info="
      INSERT INTO odoo_partner_sync_information(entity_id, action_to_sync, sync_status)
      SELECT id, 1 , 1 FROM civicrm_contact
      WHERE id NOT IN (SELECT entity_id FROM odoo_partner_sync_information);
       [nativecode=1442 ** Can't update table 'civicrm_contact' in stored function/trigger because it is already used by statement which invoked this stored function/trigger.]"]
)
```

This happen because odoo_partner_sync_information table is a custom group table that belongs to the contact entity, and any custom table that belongs to the contact entity will have some default triggers that modify the contact table last_modified_date field.  And because of that, A query like this in the installation file will result an error then we select from the contact table then insert to a table that have triggers that update the contact table again  : 

```
INSERT INTO odoo_partner_sync_information(entity_id, action_to_sync, sync_status)
SELECT id FROM civicrm_contact
WHERE id NOT IN (SELECT entity_id FROM odoo_partner_sync_information)
```



## Solution 1

I fixed this in the first commit by separating the query above to two quires , one to insert the data to a temp table, and the other to insert the data from the temp table to the custom group table.

## Problem 2

If a civicrm contact name contains Ampersand (&), then the name will appear empty when synced to odoo.


This happens because extension convert the contact data to XML before sending them to odoo, and because the Ampersand is an XML escape character then then it won't be parsed correctly and the following warning will appear : 

```
WARNING 'SimpleXMLElement::addChild(): unterminated entity reference
```

## Solution 2

I fixed this in the 2nd commit by escaping the contact data before adding them to the XML tree.

