### PR TITLE
ASE-257: Ensure Created Jobs are Disabled

### DIFF
--- a/CRM/Odoosync/Upgrader.php
+++ b/CRM/Odoosync/Upgrader.php
@@ -50,7 +50,7 @@ class CRM_Odoosync_Upgrader extends CRM_Odoosync_Upgrader_Base {
       'api_action' => 'run',
       'run_frequency' => 'Hourly',
       'domain_id' => $domainID,
-      'is_active' => '1',
+      'is_active' => 0,
       'parameters' => ''
     ];
 


### PR DESCRIPTION
## Overview
We need to check the extension's process to see if any of the scheduled jobs created by the extension are automatically turned on during the installation process.
We need to make sure all scheduled jobs created by these extensions are turned off by default.

## Before
Jobs created by this extension were enabled by default after installation

## After
Jobs created by the extension are now disabled on extension installation.