### PR TITLE
COS-46: Change error log custom fields to Note instead of normal text

### DIFF
--- a/CRM/Odoosync/Upgrader.php
+++ b/CRM/Odoosync/Upgrader.php
@@ -365,4 +365,34 @@ class CRM_Odoosync_Upgrader extends CRM_Odoosync_Upgrader_Base {
     }
   }
 
+  public function upgrade_1000() {
+    $this->changeErrorLogCustomFieldsToMemoType();
+    return TRUE;
+  }
+
+  private function changeErrorLogCustomFieldsToMemoType() {
+    $tableNames = ['odoo_invoice_sync_information', 'odoo_partner_sync_information'];
+    $customFields = civicrm_api3('CustomField', 'get', [
+      'sequential' => 1,
+      'custom_group_id' => ['IN' => $tableNames],
+      'name' => 'error_log',
+    ]);
+
+    if ($customFields['count'] == 0) {
+      return;
+    }
+    $customFields = $customFields['values'];
+
+    foreach ($tableNames as $tableName) {
+      CRM_Core_DAO::executeQuery('ALTER TABLE ' . $tableName . ' DROP INDEX INDEX_error_log');
+    }
+
+    foreach ($customFields as $customField) {
+      civicrm_api3('CustomField', 'create', [
+        'id' => $customField['id'],
+        'data_type' => 'Memo',
+        'html_type' => 'TextArea',
+      ]);
+    }
+  }
 }

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -318,8 +318,8 @@
             <column_name>error_log</column_name>
             <label>Error Log</label>
             <custom_group_name>odoo_invoice_sync_information</custom_group_name>
-            <data_type>String</data_type>
-            <html_type>Text</html_type>
+            <data_type>Memo</data_type>
+            <html_type>TextArea</html_type>
             <is_searchable>1</is_searchable>
             <is_view>1</is_view>
             <is_required>0</is_required>
@@ -463,8 +463,8 @@
             <column_name>error_log</column_name>
             <label>Error Log</label>
             <custom_group_name>odoo_partner_sync_information</custom_group_name>
-            <data_type>String</data_type>
-            <html_type>Text</html_type>
+            <data_type>Memo</data_type>
+            <html_type>TextArea</html_type>
             <is_searchable>1</is_searchable>
             <is_view>1</is_view>
             <is_required>0</is_required>


### PR DESCRIPTION
## Problem

Sometimes when the error log is too large the sync stops running with following message:

"[nativecode=1406 ** Data too long for column 'error_log' at row 1]"]"


## Solution

This is fixed by changing **Error Log** custom field for both **partner and invoice sync information** custom groups date type to Memo (Note) and the html type textArea, so the field in db will be created as a text field instead of varchar, . An upgrader is also created to update existing sites with this update.