### PR TITLE
 COS-47: Ensure that the contribution sync status is updated when updating a related line item

### DIFF
--- a/odoosync.php
+++ b/odoosync.php
@@ -168,11 +168,13 @@ function odoosync_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   }
 
   //lineItem
-  if ($objectName == 'LineItem' && isset($objectRef->entity_table)
-    && $objectRef->entity_table == 'civicrm_contribution'
+  if ($objectName == 'LineItem'
     && ($op == 'create' || $op == 'edit' || $op == 'delete')) {
-    $lineItem = new CRM_Odoosync_Hook_Post_Contribution_LineItem($op, $objectName, $objectId, $objectRef);
-    $lineItem->process();
+    $objectRef->find(TRUE);
+    if(!empty($objectRef->contribution_id)) {
+      $lineItem = new CRM_Odoosync_Hook_Post_Contribution_LineItem($op, $objectName, $objectId, $objectRef);
+      $lineItem->process();
+    }
   }
 
   //Organization, Individual


### PR DESCRIPTION
## Problem 

When using biz.jmaconsulting.lineitemedit to edit a contribution line items, this extension doesn't pick this up as a contribution change and hence doesn't sync it back to Odoo.

## Solution

The is caused because the post hook that updates the contribution sync information whenever a line item is created, update or deleted do a check to confirm that entity_table field of the line item= 'civicrm_contribution'. But there are two issues with this check : 

1- In many cases this value is empty even though it is = 'civicrm_contribution' in the database (due to a bug in civicrm), I fixed this by calling $objectRef->find(TRUE); to fetch all the line item object data.

2- Sometimes the updated line item entity_table does not = 'civicrm_contribution',  for example if someone purchased a membership then the line item entity_table will equal 'civicrm_membership', so I removed this check and replaced it with a check to confirm that the contribution_id does exist for the line item.