### PR TITLE
ASE-316: Handle odoo payments with more than one debit journal item

### DIFF
--- a/CRM/Odoosync/Sync/Inbound/Transaction.php
+++ b/CRM/Odoosync/Sync/Inbound/Transaction.php
@@ -15,12 +15,9 @@ class CRM_Odoosync_Sync_Inbound_Transaction {
     'error_message' => ''
   ];
 
-  /**
-   * Validated params
-   *
-   * @var array
-   */
-  private $validatedParams = [];
+  private $validatedCommonParams = [];
+
+  private $validatedTransactionParamsList = [];
 
   /**
    * Starts transaction sync from Odoo
@@ -61,7 +58,19 @@ class CRM_Odoosync_Sync_Inbound_Transaction {
     if (isset($response->params->param->value->struct->financial_trxn)) {
       foreach ($response->params->param->value->struct->financial_trxn as $param) {
         if (!empty($param->name) && !empty($param->value)) {
-          $parsedData[(string) $param->name] = (string) $param->value;
+          if (isset($param->value->list->record)) {
+            $parsedRecords = [];
+            foreach ($param->value->list->record as $record) {
+              $parsedRecord = [];
+              foreach ($record->param as $listParam) {
+                $parsedRecord[(string) $listParam->name] = (string) $listParam->value;
+              }
+              $parsedRecords[] = $parsedRecord;
+            }
+            $parsedData[(string) $param->name] = $parsedRecords;
+          } else {
+            $parsedData[(string) $param->name] = (string) $param->value;
+          }
         }
       }
     }
@@ -81,13 +90,11 @@ class CRM_Odoosync_Sync_Inbound_Transaction {
    */
   private function validateParams($params) {
     $fields = [
-      "total_amount",
       "trxn_date",
       "invoice_id",
       "currency",
-      "credit_account_code",
       "contribution_status",
-      "to_financial_account_name"
+      "to_financial_account_name",
     ];
 
     $validParam = [];
@@ -103,11 +110,34 @@ class CRM_Odoosync_Sync_Inbound_Transaction {
       }
     }
 
+    if (!empty($params['transactions'])) {
+      $validParam['transactions'] = $params['transactions'];
+    } else {
+      $this->syncResponse['is_error'] = 1;
+      $this->syncResponse['error_message'] .= ts("transactions is a required field");
+      return;
+    }
+
+    foreach ($validParam['transactions'] as &$transaction) {
+      $fields = [
+        'credit_account_code',
+        'total_amount',
+      ];
+      foreach ($fields as $fieldName) {
+        if (isset($transaction[$fieldName])) {
+          $transaction[$fieldName] = trim($transaction[$fieldName]);
+        }
+        else {
+          $this->syncResponse['is_error'] = 1;
+          $this->syncResponse['error_message'] .= ts("Transaction: %1 field is required", [1 => $fieldName]);
+          return;
+        }
+      }
+    }
+
     $contributionId = $validParam['invoice_id'];
     $toFinancialAccountName = $validParam['to_financial_account_name'];
-    $creditAccountCode = $validParam['credit_account_code'];
     $toFinancialAccountId = $this->getFinancialAccountIdByName($toFinancialAccountName);
-    $fromFinancialAccountId = $this->getFinancialAccountIdByCode($creditAccountCode);
     $contributionStatusId = $this->getContributionStatusId($validParam['contribution_status']);
 
     if (!$this->isContributionExist($contributionId)) {
@@ -121,24 +151,30 @@ class CRM_Odoosync_Sync_Inbound_Transaction {
       $this->syncResponse['error_message'] .= ts("Financial account (with 'name' = '%1') doesn't exist.", [1 => $toFinancialAccountName]);
     }
 
-    if (!$fromFinancialAccountId) {
-      $this->syncResponse['is_error'] = 1;
-      $this->syncResponse['error_message'] .= ts("Financial account (with 'accounting code' = '%1') doesn't exist.", [1 => $fromFinancialAccountId]);
-    }
-
     if (!$contributionStatusId) {
       $this->syncResponse['is_error'] = 1;
       $this->syncResponse['error_message'] .= ts("Contribution status '%1' doesn't exist.", [1 => $validParam['contribution_status']]);
+    }
+
+    foreach ($validParam['transactions'] as $transactionRecord) {
+      $fromFinancialAccountId = $this->getFinancialAccountIdByCode($transactionRecord['credit_account_code']);
+      if (!$fromFinancialAccountId) {
+        $this->syncResponse['is_error'] = 1;
+        $this->syncResponse['error_message'] .= ts("Financial account (with 'accounting code' = '%1') doesn't exist.", [1 => $fromFinancialAccountId]);
+      }
+
+      $this->validatedTransactionParamsList[] = [
+        'from_financial_account_id' => $fromFinancialAccountId,
+        'total_amount' => $transactionRecord['total_amount'],
+      ];
     }
 
     if ($this->syncResponse['is_error'] === 1) {
       return;
     }
 
-    $this->validatedParams =  [
+    $this->validatedCommonParams  =  [
       'to_financial_account_id' => $toFinancialAccountId,
-      'from_financial_account_id' => $fromFinancialAccountId,
-      'total_amount' => $validParam['total_amount'],
       'trxn_date' => CRM_Odoosync_Common_Date::convertTimestampToDate($validParam['trxn_date']),
       'currency' => $validParam['currency'],
       'contribution_id' => $contributionId,
@@ -238,29 +274,35 @@ class CRM_Odoosync_Sync_Inbound_Transaction {
    * Creates transaction
    */
   private function syncTransactions() {
-    $financialTrxnId = $this->createFinancialTrxn();
+    foreach ($this->validatedTransactionParamsList as $transactionParams) {
+      $financialTrxnId = $this->createFinancialTrxn($transactionParams);
 
-    if (!$financialTrxnId ) {
-      $this->syncResponse['is_error'] = 1;
-      $this->syncResponse['error_message'] .= ts("Can't create financial transaction.");
-      return;
+      if (!$financialTrxnId) {
+        $this->syncResponse['is_error'] = 1;
+        $this->syncResponse['error_message'] .= ts("Can't create financial transaction.");
+        return;
+      }
+
+      $this->createEntityFinancialTrxn($financialTrxnId, $transactionParams['total_amount']);
+
+      $this->syncResponse['transactions'][] = [
+        'id' => $financialTrxnId,
+        'timestamp' =>  time(),
+      ];
     }
 
-    $this->createEntityFinancialTrxn($financialTrxnId);
     $this->updateContributionStatus();
-
-    $this->syncResponse['transaction_id'] = $financialTrxnId;
-    $this->syncResponse['timestamp'] = time();
   }
 
   /**
    * Creates connect transaction to 'financial item'
    *
    * @param $financialTrxnId
+   * @param $amount
    *
    * @return bool
    */
-  private function createEntityFinancialTrxn($financialTrxnId) {
+  private function createEntityFinancialTrxn($financialTrxnId, $amount) {
     $financialItemId = $this->getFinancialItemId();
     if (!$financialItemId) {
       return FALSE;
@@ -271,7 +313,7 @@ class CRM_Odoosync_Sync_Inbound_Transaction {
         'entity_table' => 'civicrm_financial_item',
         'entity_id' => $financialItemId,
         'financial_trxn_id' => $financialTrxnId,
-        'amount' =>  $this->validatedParams['total_amount']
+        'amount' =>  $amount,
       ]);
 
       return (int) $entityFinancialTrxn['id'];
@@ -298,7 +340,7 @@ class CRM_Odoosync_Sync_Inbound_Transaction {
         AND line_item.entity_table = 'civicrm_contribution'
         AND financial_item.entity_table = 'civicrm_line_item'
 	  ";
-    $dao = CRM_Core_DAO::executeQuery($query, [1 => [$this->validatedParams['contribution_id'], 'Integer']]);
+    $dao = CRM_Core_DAO::executeQuery($query, [1 => [$this->validatedCommonParams['contribution_id'], 'Integer']]);
 
     while ($dao->fetch()) {
       return (int) $dao->financial_item_id;
@@ -311,14 +353,16 @@ class CRM_Odoosync_Sync_Inbound_Transaction {
   /**
    * Creates financial transaction
    *
+   * @param array $transactionParams
+   *
    * @return bool|int
    */
-  private function createFinancialTrxn() {
+  private function createFinancialTrxn($transactionParams) {
     try {
-      $params = array_merge($this->validatedParams, [
+      $params = array_merge($this->validatedCommonParams, [
         'is_payment' => 1,
-        'net_amount' => $this->validatedParams['total_amount']
-      ]);
+        'net_amount' => $transactionParams['amount']
+      ], $transactionParams);
       $financialTrxn = civicrm_api3('FinancialTrxn', 'create', $params);
 
       return (int) $financialTrxn["id"];
@@ -334,7 +378,7 @@ class CRM_Odoosync_Sync_Inbound_Transaction {
   private function updateContributionStatus() {
     $currentContributionStatus = $this->getCurrentContributionStatus();
 
-    if ($currentContributionStatus == $this->validatedParams['contribution_status_id']) {
+    if ($currentContributionStatus == $this->validatedCommonParams['contribution_status_id']) {
       return;
     }
 
@@ -345,8 +389,8 @@ class CRM_Odoosync_Sync_Inbound_Transaction {
     ";
 
     CRM_Core_DAO::executeQuery($query, [
-      1 => [$this->validatedParams['contribution_id'], 'Integer'],
-      2 => [$this->validatedParams['contribution_status_id'], 'String'],
+      1 => [$this->validatedCommonParams['contribution_id'], 'Integer'],
+      2 => [$this->validatedCommonParams['contribution_status_id'], 'String'],
     ]);
   }
 
@@ -356,7 +400,7 @@ class CRM_Odoosync_Sync_Inbound_Transaction {
   private function getCurrentContributionStatus() {
     return civicrm_api3('Contribution', 'getvalue', [
       'return' => "contribution_status_id",
-      'id' => $this->validatedParams['contribution_id']
+      'id' => $this->validatedCommonParams['contribution_id']
     ]);
   }
 
@@ -368,7 +412,17 @@ class CRM_Odoosync_Sync_Inbound_Transaction {
     $result = $xml->addChild('Result');
 
     foreach ($this->syncResponse as $name => $value) {
-      $result->addChild($name, $value);
+      if(is_array($value)) {
+        $arrayParent = $result->addChild($name);
+        foreach ($value as $arrayChildValue) {
+          $recordElement = $arrayParent->addChild('record');
+          foreach ($arrayChildValue as $arrayChildValueName => $arrayChildValueValue) {
+            $recordElement->addChild($arrayChildValueName, $arrayChildValueValue);
+          }
+        }
+      } else {
+        $result->addChild($name, $value);
+      }
     }
 
     echo $xml->asXML();


### PR DESCRIPTION
## Related PR 
https://github.com/compucorp/odoo_civicrm_sync/pull/25


## The Problem

Suppose the user purchased 5 books where each book costs 28$ plus a 3.5$ shipping cost, in this case the 'income account' will be credited with 143.5$ and the 'account receivable'
will be debited with 143.5$ .

The info above will be stored correctly on booth Civicrm and Odoo, but now and if for some reason the user only paid only 31.5$ since he received only one book of the 5 
that he was supposed to receive (28$ is the price of one book + 3.5$ shipping), in this case the 'account receivable' will be credited with 31.5$ and the 'bank' account
will be debited with 31.5$, and 'account receivable' will also be credited with $112 (the price of the 4 remaining books) and the 'income account' will be debited with 
$112 .

All the payment info above will be stored correctly on Odoo side as you can see in the picture below :

![2018-12-10 17_59_00-meet tjy-zekd-dsy](https://user-images.githubusercontent.com/6275540/50219901-8b5bde00-0388-11e9-8ed4-43860bc553ad.png)


But now when we run the scheduled job that sync Odoo payments to Civicrm, the sync will fails, and the reason is that the Odoo module work on the assumption
that the payment will be made in full so only one debit and one credit journal items will be stored and it use the debit journal item account code for the mapping with 
from_financial_account_id field on Civicrm FinancialTrxn entity. But because we have two debit journal items in the example above, the code won't know which to pick
and it will fail and stop the sync from running.

## The solution

We are now syncing both debit journal items to Civicrm , so instead of creating one FinancialTrxn entity record, two records will be created instead for each  journal item in the example above (or more than two records if there are more than two debit journal items).

The code in this PR accepts the new api request format sent from odoo, so before it was like this : 

```
[
	{"to_financial_account_name": payment.journal_id.name},
	{"total_amount": payment.amount},
	{"trxn_date": int(payment_date)},
	{"currency": payment.currency_id.name},
	{"invoice_id": payment_to_invoice.x_civicrm_id},
	{"credit_account_code": debit_line.account_id.code},
	{"contribution_status": self._convert_invoice_state(invoice_state)},
]
```

but now we are sending it like this : 

```
[
	{"to_financial_account_name": payment.journal_id.name},
	{"trxn_date": int(payment_date)},
	{"currency": payment.currency_id.name},
	{"invoice_id": payment_to_invoice.x_civicrm_id},
	{"contribution_status": self._convert_invoice_state(invoice_state)},
	{"transactions": transactions},
]
```

where **transactions** is the list that contain all the debit journal items in that payment and each element in that list contain two info : 
1- credit_account_code : which is the  account code for that journal item.
 2- total_amount : which is the debit amount of that journal item.

and for each transaction in the **transactions** element, a new civicrm **financial transaction** record will be created as well as one **financial entity transaction** record.

it will also now instead of sending back one transaction_id to odoo, an array of all transactions ids will be sent for odoo to map the payment with transaction properly.
