### PR TITLE
ASESPRT-225: Fix date handling for invoice related dates

### DIFF
--- a/CRM/Odoosync/Sync/Contribution/Data/ContributionParam.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/ContributionParam.php
@@ -11,8 +11,6 @@ class CRM_Odoosync_Sync_Contribution_Data_ContributionParam extends CRM_Odoosync
   public function retrieve() {
     $contributionData = $this->getContributionData();
     $actionToSyncValueId = $contributionData->action_to_sync;
-    $receiveDateTimestamp = CRM_Odoosync_Common_Date::convertDateToTimestamp($contributionData->receive_date);
-    $receiveDateTimestampWithTimezone = $receiveDateTimestamp + (new DateTime())->getOffset();
     $actionDateTimestamp = CRM_Odoosync_Common_Date::convertDateToTimestamp($contributionData->action_date);
     $actionToSyncName = CRM_Odoosync_Common_OptionValue::getOptionName('odoo_invoice_action_to_sync', $actionToSyncValueId);
     $contactId = $contributionData->contact_id;
@@ -54,8 +52,8 @@ class CRM_Odoosync_Sync_Contribution_Data_ContributionParam extends CRM_Odoosync
       ],
       [
         'name' => 'date_invoice',
-        'type' => 'int',
-        'value' => $receiveDateTimestampWithTimezone
+        'type' => 'string',
+        'value' => (new DateTime($contributionData->receive_date))->format('Y-m-d')
       ],
       [
         'name' => 'action_to_sync',

--- a/CRM/Odoosync/Sync/Contribution/Data/Payment.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/Payment.php
@@ -63,8 +63,6 @@ class CRM_Odoosync_Sync_Contribution_Data_Payment extends CRM_Odoosync_Sync_Cont
     $paymentItems = [];
 
     while ($paymentItemsDao->fetch()) {
-      $paymentDate = CRM_Odoosync_Common_Date::convertDateToTimestamp($paymentItemsDao->payment_date);
-      $paymentDateWithTimezone = $paymentDate + (new DateTime())->getOffset();
       $paymentItems[] = [
         [
           'name' => 'status',
@@ -88,8 +86,8 @@ class CRM_Odoosync_Sync_Contribution_Data_Payment extends CRM_Odoosync_Sync_Cont
         ],
         [
           'name' => 'payment_date',
-          'type' => 'int',
-          'value' => $paymentDateWithTimezone
+          'type' => 'string',
+          'value' => (new DateTime($paymentItemsDao->payment_date))->format('Y-m-d')
         ],
         [
           'name' => 'communication',

--- a/CRM/Odoosync/Sync/Contribution/Data/Refund.php
+++ b/CRM/Odoosync/Sync/Contribution/Data/Refund.php
@@ -43,13 +43,11 @@ class CRM_Odoosync_Sync_Contribution_Data_Refund extends CRM_Odoosync_Sync_Contr
     $refundItems = [];
 
     while ($dao->fetch()) {
-      $date = CRM_Odoosync_Common_Date::convertDateToTimestamp($dao->payment_date);
-      $dateWithTimezone = $date + (new DateTime())->getOffset();
       $refundItems[] = [
         [
           'name' => 'date',
-          'type' => 'int',
-          'value' => $dateWithTimezone
+          'type' => 'string',
+          'value' => (new DateTime($dao->payment_date))->format('Y-m-d')
         ],
         [
           'name' => 'description',


### PR DESCRIPTION
## Before

1- Create a membership with payment plan for let's say 12 installments every 1 month starting from 01/01/2020

2- Then sync it to odoo and check the invoices --> you will see that the invoices between April and November are incorrect, they are one day before the actual dates on the contributions --> same happens with transactions too if the date of the transaction is for example '01/07/2019 00:00:00', it will be '30/06/2019' in odoo.

The issue happen when the CiviCRM server timezone is something other than UTC (e.g London) as the following : 

A- When a contribution with a receive date as `2020-06-01 00:00:00` is synced to odoo the (and given that the timezone of the CiviCRM server is London time), this extension will convert the date to a timestamp before sending it odoo. but there is 1 hour daylight saving at such date, so London time is basically UTC+1 at that date, so the cosponsoring date for the above date in UTC is actually `2020-05-31 11:00:00` , and since the timestamp calculation is based on UTC, the resulted timestamp will be `1590966000` and it is the timestamp that will be sent to odoo.

B- The odoo module will read the timestamp and convert it back to normal date before storing it into the invoice table, and hence that the invoice field is a date only field on odoo so the time part of the time will be removed, and the resulted date of converting the above timestamp will be `2020-05-31` since again converting a timestamp to date will be done in relative to the Utc timezone (and given that odoo server deals with all dates in Utc so it will not correct the date to London timezone after converting it) and hence that the date of the invoice will be stored as `2020-05-31`.


## After

Our goal here is that the date that is set during the creation of the payment plan on CiviCRM (or the contribution) should be the same on the odoo invoice, and given that the date is stored in odoo (for the invoice) without the time, it means that the timezone is not much relevant here, and so whatever the date CiviCRM outputs should be stored as is in odoo.

So here I changed the way CiviCRM send the date to odoo, so instead of converting the date to a timestamp before sending it to odoo, I convert it to a date string without the time (using this format `Y-m-d`), so in the example above the following will be sent to odoo `2020-06-01` instead of   `1590966000`.

This also required changing how the odoo module parse the date, so  I changed the odoo module here so it expect a date instead of a timestamp : 

https://github.com/compucorp/odoo_civicrm_sync/pull/39

and thus, the date will be stored as is and will appear to the users on odoo same as it appear on CiviCRM.

