### PR TITLE
ASESPRT-311: Add more logging mechanism 

### DIFF
--- a/CRM/Odoosync/Sync.php
+++ b/CRM/Odoosync/Sync.php
@@ -21,16 +21,19 @@ class CRM_Odoosync_Sync {
 
     $log['is_error'] = ($logContact['is_error'] == 1 || $logContact['is_error'] == 1) ? 1 : 0;
 
-    //more detail log can view in api when debug = 1
+    //this log can view on schedule job
+    $log['values'] = '<br/>' . $logContact['values'] . $logContribution['values'];
+    $log['values'] .= !empty($mailLog) ? '<br/>' . $mailLog : '';
+
+    //View more detail log in api explorer
+    //and write debug log into CiviCRM log
+    //when debug = 1 is passed as parameter
     if ($params['debug'] == 1) {
       $log['debugLog']['contacts_debug_log'] = $logContact['debugLog'];
       $log['debugLog']['contribution_debug_log'] = $logContribution['debugLog'];
       $log['debugLog']['mail_debug_log'] = $mailLog;
+      Civi::log()->debug(print_r($log['debugLog'],true));
     }
-
-    //this log can view on schedule job
-    $log['values'] = '<br/>' . $logContact['values'] . $logContribution['values'];
-    $log['values'] .= !empty($mailLog) ? '<br/>' . $mailLog : '';
 
     return $log;
   }

--- a/CRM/Odoosync/Sync/Contribution.php
+++ b/CRM/Odoosync/Sync/Contribution.php
@@ -92,8 +92,10 @@ class CRM_Odoosync_Sync_Contribution extends CRM_Odoosync_Sync_BaseHandler {
    */
   private function handleSuccessResponse($creditNoteNumber, $invoiceNumber, $timestamp) {
     $this->setJobLog(ts('Sync with success. Contribution id = %1.', [1 => $this->syncContributionId]));
+    $responseHandlerLog = [];
     $responseHandler = new CRM_Odoosync_Sync_Contribution_ResponseHandler();
-    $responseHandler->handleSuccess($this->syncContributionId, $creditNoteNumber, $invoiceNumber, $timestamp);
+    $responseHandler->handleSuccess($this->syncContributionId, $creditNoteNumber, $invoiceNumber, $timestamp,$responseHandlerLog);
+    $this->setlog($responseHandlerLog);
     $this->setLog(ts('Successful sync. Contribution data updated.'));
   }
 
@@ -107,16 +109,18 @@ class CRM_Odoosync_Sync_Contribution extends CRM_Odoosync_Sync_BaseHandler {
    */
   private function handleErrorResponse($errorMessage, $timestamp) {
     $this->setJobLog(ts('Sync with error. Contribution id = %1.', [1 => $this->syncContributionId]));
-
+    $responseHandlerLog = [];
     $responseHandler = new CRM_Odoosync_Sync_Contribution_ResponseHandler();
     $isReachedRetryThreshold = $responseHandler->handleError(
       $errorMessage,
       $this->setting['odoosync_retry_threshold'],
       $this->syncContributionId,
-      $timestamp
+      $timestamp,
+      $responseHandlerLog
     );
     $this->setLog(ts('Sync with error. Contribution data updated.'));
     $this->setLog($errorMessage);
+    $this->setLog($responseHandlerLog);
 
     if ($isReachedRetryThreshold) {
       $this->setLog(ts("Reached retry threshold counter. 'Sync Status' marked as 'Sync failed. Prepare sending errors to emails.'"));


### PR DESCRIPTION
## Overview

This PR adds functionality to write debug logs into CiviCRM log files when debug parameter is passed to the schedule API. 

The addtional logs are also added to log handle Odoo response both either sync success or fail. 

### Before

The debug data can only be obtained when using API explorer to call the Odoo sync API, and the debug log does not capture anywhere. 

### After

The debug data will be written to CiviCRM log under ConfigAndLog directory (see https://docs.civicrm.org/dev/en/latest/framework/filesystem/#local-data-files). 

### Technical details

The sync extension will try the data into the log file only when debug=1 is passed to parameter. 